### PR TITLE
Add client settings for Redis to appsettings.json

### DIFF
--- a/Connectors/src/AspDotNetCore/Redis/appsettings.json
+++ b/Connectors/src/AspDotNetCore/Redis/appsettings.json
@@ -4,5 +4,10 @@
     "LogLevel": {
       "Default": "Warning"
     }
+  },
+  "redis": {
+    "client": {
+      "connectRetry": 3
+    }
   }
 }


### PR DESCRIPTION
It was really painful to try to reverse engineer what the configuration was supposed to look like for the Redis client. You can _sort of_ find it in unit tests in the Connectors repo, but the samples should probably show it directly... so here it is.