### PR TITLE
Reference USE_REDIS_CACHE environment variable

### DIFF
--- a/MusicStore/pushMusicStoreUI.sh
+++ b/MusicStore/pushMusicStoreUI.sh
@@ -17,7 +17,7 @@ fi
 r=$1
 nixmanifest=manifest.yml
 winmanifest=manifest-windows.yml
-if [ "USE_REDIS_CACHE" == "true" ]; then
+if [ "$USE_REDIS_CACHE" == "true" ]; then
 	nixmanifest=manifest-redis.yml
 	winmanifest=manifest-windows-redis.yml
 fi


### PR DESCRIPTION
Instead of comparing the literal string "USE_REDIS_CACHE" to "true", reference the environment variable `$USE_REDIS_CACHE`.