### PR TITLE
URL Cleanup

### DIFF
--- a/ci/docker/behave/Dockerfile
+++ b/ci/docker/behave/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get -y install dotnet-sdk-2.1.300-rc1-008673
 
 # CloudFoundry
 RUN curl https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key | apt-key add -
-RUN echo "deb http://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list
+RUN echo "deb https://packages.cloudfoundry.org/debian stable main" > /etc/apt/sources.list.d/cloudfoundry-cli.list
 RUN apt-get update
 RUN apt-get -y install cf-cli
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://packages.cloudfoundry.org/debian (404) migrated to:  
  https://packages.cloudfoundry.org/debian ([https](https://packages.cloudfoundry.org/debian) result 404).