### PR TITLE
URL Cleanup

### DIFF
--- a/CircuitBreaker/src/AspDotNet4/FortuneTeller/Fortune-Teller-UI4/fonts/glyphicons-halflings-regular.svg
+++ b/CircuitBreaker/src/AspDotNet4/FortuneTeller/Fortune-Teller-UI4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNet4/AutofacCloudFoundry/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNet4/AutofacCloudFoundry/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNet4/Simple/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNet4/Simple/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNet4/SimpleCloudFoundry/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNet4/SimpleCloudFoundry/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNetCore/CloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNetCore/Simple/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNetCore/Simple/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Configuration/src/AspDotNetCore/SimpleCloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Configuration/src/AspDotNetCore/SimpleCloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/MsSql4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/MsSql4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/MySql4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/MySql4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/OAuth4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/OAuth4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/PostgreSql4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/PostgreSql4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/RabbitMQ4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/RabbitMQ4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNet4/Redis4/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNet4/Redis4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/MySql/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/MySql/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/MySqlEF6/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/MySqlEF6/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/MySqlEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/MySqlEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/OAuth/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/OAuth/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/PostgreEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/PostgreEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/PostgreSql/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/PostgreSql/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/RabbitMQ/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/RabbitMQ/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/Redis/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/Redis/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Connectors/src/AspDotNetCore/SqlServerEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Connectors/src/AspDotNetCore/SqlServerEFCore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Discovery/src/AspDotNet4/Fortune-Teller-UI4/fonts/glyphicons-halflings-regular.svg
+++ b/Discovery/src/AspDotNet4/Fortune-Teller-UI4/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/FreddysBBQ/src/AdminPortal/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/FreddysBBQ/src/AdminPortal/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Management/src/AspDotNet4/CloudFoundryOwin/fonts/glyphicons-halflings-regular.svg
+++ b/Management/src/AspDotNet4/CloudFoundryOwin/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Management/src/AspDotNet4/CloudFoundryOwinAutofac/fonts/glyphicons-halflings-regular.svg
+++ b/Management/src/AspDotNet4/CloudFoundryOwinAutofac/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Management/src/AspDotNet4/CloudFoundryWeb/fonts/glyphicons-halflings-regular.svg
+++ b/Management/src/AspDotNet4/CloudFoundryWeb/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Management/src/AspDotNetCore/CloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Management/src/AspDotNetCore/CloudFoundry/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/MusicStore/src/MusicStoreUI/wwwroot/Images/logo.svg
+++ b/MusicStore/src/MusicStoreUI/wwwroot/Images/logo.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -57,7 +57,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
         <dc:title />
       </cc:Work>
     </rdf:RDF>

--- a/MusicStore/src/MusicStoreUI/wwwroot/Images/placeholder.svg
+++ b/MusicStore/src/MusicStoreUI/wwwroot/Images/placeholder.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<!-- Created with Inkscape (https://www.inkscape.org/) -->
 
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -46,7 +46,7 @@
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+           rdf:resource="https://purl.org/dc/dcmitype/StillImage" />
         <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>

--- a/MusicStore/src/MusicStoreUI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/MusicStore/src/MusicStoreUI/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Security/src/AspDotNetCore/CredHubDemo/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Security/src/AspDotNetCore/CredHubDemo/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
+++ b/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/wwwroot/lib/bootstrap/dist/fonts/glyphicons-halflings-regular.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/1999/02/22-rdf-syntax-ns with 2 occurrences migrated to:  
  https://www.w3.org/1999/02/22-rdf-syntax-ns ([https](https://www.w3.org/1999/02/22-rdf-syntax-ns) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 35 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://www.inkscape.org/ with 2 occurrences migrated to:  
  https://www.inkscape.org/ ([https](https://www.inkscape.org/) result 301).
* [ ] http://purl.org/dc/dcmitype/StillImage with 2 occurrences migrated to:  
  https://purl.org/dc/dcmitype/StillImage ([https](https://purl.org/dc/dcmitype/StillImage) result 302).

# Ignored
These URLs were intentionally ignored.

* http://creativecommons.org/ns with 2 occurrences
* http://purl.org/dc/elements/1.1/ with 2 occurrences
* http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd with 2 occurrences
* http://www.inkscape.org/namespaces/inkscape with 2 occurrences
* http://www.w3.org/2000/svg with 119 occurrences