### PR TITLE
Added handling for SSL offloading in the Owin pipeline.

### DIFF
--- a/Security/src/AspDotNet4/CloudFoundrySingleSignon/App_Start/Startup.Auth.cs
+++ b/Security/src/AspDotNet4/CloudFoundrySingleSignon/App_Start/Startup.Auth.cs
@@ -15,6 +15,21 @@ namespace CloudFoundrySingleSignon
         // For more information on configuring authentication, please visit https://go.microsoft.com/fwlink/?LinkId=301864
         public void ConfigureAuth(IAppBuilder app)
         {
+            /*
+             * When SSL is offloaded by a proxy or load balancer, the "X-Forwarded-Proto" header is set to "https". 
+             * The Request in the context will be set to a scheme of "http" being as SSL was offloaded. It is 
+             * necessary to change the scheme on the Request object to "https" so that redirect URLs generated 
+             * by middleware use the client scheme which was "https" as noted by the header.
+             */
+            app.Use((context, next) =>
+            {
+                if (context.Request.Headers["X-Forwarded-Proto"] == "https" && context.Request.Scheme != "https")
+                {
+                    context.Request.Scheme = "https";
+                }
+                return next();
+            });
+            
             app.SetDefaultSignInAsAuthenticationType("ExternalCookie");
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {


### PR DESCRIPTION
When SSL is offloaded by a proxy or load balancer, the "X-Forwarded-Proto" header is set to "https". The Request in the context will be set to a scheme of "http" being as SSL was offloaded. It is necessary to change the scheme on the Request object to "https" so that redirect URLs generated by middleware use the client scheme which was "https" as noted by the header. Reference: https://docs.microsoft.com/en-us/aspnet/core/security/authentication/cookie?view=aspnetcore-2.2. This goes for framework and core. I encountered this in the redirect url generated by Microsoft.Owin.Security.Cookies.