### PR TITLE
Freddys BBQ Sample Target Framework Update

### DIFF
--- a/FreddysBBQ/FreddysBBQ.sln
+++ b/FreddysBBQ/FreddysBBQ.sln
@@ -1,10 +1,12 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{69941B37-30A6-4301-9705-A91CC58F3237}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdminPortal", "src\AdminPortal\AdminPortal.csproj", "{C90ABB0A-4E9E-472F-9A27-7078D31FB605}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "src\Common\Common.csproj", "{FC6A013F-5FF0-4F0A-85FF-36C878536C38}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OrderService", "src\OrderService\OrderService.csproj", "{DD3451E8-F707-4FF2-88CE-F2CFE5768F66}"
 EndProject
@@ -53,6 +55,18 @@ Global
 		{DD3451E8-F707-4FF2-88CE-F2CFE5768F66}.Release|x64.Build.0 = Release|Any CPU
 		{DD3451E8-F707-4FF2-88CE-F2CFE5768F66}.Release|x86.ActiveCfg = Release|Any CPU
 		{DD3451E8-F707-4FF2-88CE-F2CFE5768F66}.Release|x86.Build.0 = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|x64.Build.0 = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -60,6 +74,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{C90ABB0A-4E9E-472F-9A27-7078D31FB605} = {69941B37-30A6-4301-9705-A91CC58F3237}
 		{DD3451E8-F707-4FF2-88CE-F2CFE5768F66} = {69941B37-30A6-4301-9705-A91CC58F3237}
+		{FC6A013F-5FF0-4F0A-85FF-36C878536C38} = {69941B37-30A6-4301-9705-A91CC58F3237}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B759E399-9704-422E-9229-68C3FBFDB58A}

--- a/FreddysBBQ/README.md
+++ b/FreddysBBQ/README.md
@@ -80,8 +80,8 @@ cf delete order-service -f
 dotnet publish -f netcoreapp3.1 -r win10-x64
 cf push -f manifest-windows.yml -p bin\Debug\netcoreapp3.1\win10-x64\publish
 # OR for Linux
-dotnet publish -f netcoreapp3.1 -r ubuntu.16.04-x64
-cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\ubuntu.16.04-x64\publish
+dotnet publish -f netcoreapp3.1 -r linux-x64
+cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\linux-x64\publish
 
 cd ..\AdminPortal
 cf delete admin-portal -f

--- a/FreddysBBQ/README.md
+++ b/FreddysBBQ/README.md
@@ -89,8 +89,8 @@ cf delete admin-portal -f
 dotnet publish -f netcoreapp3.1 -r win10-x64
 cf push -f manifest-windows.yml -p bin\Debug\netcoreapp3.1\win10-x64\publish
 # OR for Linux
-dotnet publish -f netcoreapp3.1 -r ubuntu.16.04-x64
-cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\ubuntu.16.04-x64\publish
+dotnet publish -f netcoreapp3.1 -r linux-x64
+cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\linux-x64\publish
 ```
 
 At this point the app should continue to work as it did before.  Any orders you might have had before, will be gone as you are now starting with a new clean order database. 

--- a/FreddysBBQ/README.md
+++ b/FreddysBBQ/README.md
@@ -77,20 +77,20 @@ At this point you are ready to replace the existing Java based services with the
 cd Samples\FreddysBBQ\src\OrderService
 cf delete order-service -f
 # Publish & Push to run on Windows
-dotnet publish -f netcoreapp2.1 -r win10-x64
-cf push -f manifest-windows.yml -p bin\Debug\netcoreapp2.1\win10-x64\publish
+dotnet publish -f netcoreapp3.1 -r win10-x64
+cf push -f manifest-windows.yml -p bin\Debug\netcoreapp3.1\win10-x64\publish
 # OR for Linux
-dotnet publish -f netcoreapp2.1 -r ubuntu.16.04-x64
-cf push -f manifest.yml -p bin\Debug\netcoreapp2.1\ubuntu.16.04-x64\publish
+dotnet publish -f netcoreapp3.1 -r ubuntu.16.04-x64
+cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\ubuntu.16.04-x64\publish
 
 cd ..\AdminPortal
 cf delete admin-portal -f
 # Publish & Push to run on Windows
-dotnet publish -f netcoreapp2.1 -r win10-x64
-cf push -f manifest-windows.yml -p bin\Debug\netcoreapp2.1\win10-x64\publish
+dotnet publish -f netcoreapp3.1 -r win10-x64
+cf push -f manifest-windows.yml -p bin\Debug\netcoreapp3.1\win10-x64\publish
 # OR for Linux
-dotnet publish -f netcoreapp2.1 -r ubuntu.16.04-x64
-cf push -f manifest.yml -p bin\Debug\netcoreapp2.1\ubuntu.16.04-x64\publish
+dotnet publish -f netcoreapp3.1 -r ubuntu.16.04-x64
+cf push -f manifest.yml -p bin\Debug\netcoreapp3.1\ubuntu.16.04-x64\publish
 ```
 
 At this point the app should continue to work as it did before.  Any orders you might have had before, will be gone as you are now starting with a new clean order database. 

--- a/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
+++ b/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
@@ -5,11 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\Common\Services\*.cs" />
-    <Compile Include="..\Common\Models\*.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Steeltoe.Connector.EFCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
@@ -20,5 +15,9 @@
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
+++ b/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
@@ -15,10 +15,10 @@
     <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
-    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
+    <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
+++ b/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\config\versions.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,17 +10,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.Connector.EFCore" Version="$(SteeltoeConnectorVersion)" />
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeLoggingVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Steeltoe.Connector.EFCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
     <PackageReference Include="System.Net.Sockets" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />
-    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeDiscoveryVersion)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeConfigVersion)" />
-    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeSecurityVersion)" />
+    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
+++ b/FreddysBBQ/src/AdminPortal/AdminPortal.csproj
@@ -6,11 +6,13 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.EFCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="System.Diagnostics.Tools" Version="4.3.0" />

--- a/FreddysBBQ/src/AdminPortal/Program.cs
+++ b/FreddysBBQ/src/AdminPortal/Program.cs
@@ -1,8 +1,5 @@
-﻿using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Logging;
-using Steeltoe.Extensions.Configuration.CloudFoundry;
-using Steeltoe.Extensions.Logging;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace AdminPortal
 {
@@ -10,19 +7,14 @@ namespace AdminPortal
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-                WebHost.CreateDefaultBuilder(args)
-                        .UseCloudFoundryHosting()
-                        .AddCloudFoundry()
-                        .ConfigureLogging((builderContext, loggingBuilder) =>
-                        {
-                            loggingBuilder.AddConfiguration(builderContext.Configuration.GetSection("Logging"));
-                            loggingBuilder.AddDynamicConsole();
-                        })
-                        .UseStartup<Startup>()
-                        .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/FreddysBBQ/src/AdminPortal/Program.cs
+++ b/FreddysBBQ/src/AdminPortal/Program.cs
@@ -1,5 +1,8 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
+using Steeltoe.Common.Hosting;
+using Steeltoe.Extensions.Configuration.CloudFoundry;
+using Steeltoe.Extensions.Logging;
 
 namespace AdminPortal
 {
@@ -12,9 +15,12 @@ namespace AdminPortal
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .AddCloudFoundryConfiguration()
+                .AddDynamicLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                });
+                })
+                .UseCloudHosting();
     }
 }

--- a/FreddysBBQ/src/AdminPortal/Startup.cs
+++ b/FreddysBBQ/src/AdminPortal/Startup.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Steeltoe.Discovery.Client;
 using Steeltoe.Security.Authentication.CloudFoundry;
 
@@ -51,12 +52,11 @@ namespace AdminPortal
             services.AddSingleton<IMenuService, MenuService>();
             services.AddSingleton<IOrderService, OrderService>();
 
-            // Add framework services.
-            services.AddMvc();
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -74,13 +74,15 @@ namespace AdminPortal
                 ForwardedHeaders = ForwardedHeaders.XForwardedProto
             });
 
+            app.UseRouting();
+
             app.UseAuthentication();
 
-            app.UseMvc(routes =>
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
             });
 
             app.UseDiscoveryClient();

--- a/FreddysBBQ/src/AdminPortal/Startup.cs
+++ b/FreddysBBQ/src/AdminPortal/Startup.cs
@@ -78,6 +78,8 @@ namespace AdminPortal
 
             app.UseAuthentication();
 
+            app.UseAuthorization();
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(

--- a/FreddysBBQ/src/Common/Common.csproj
+++ b/FreddysBBQ/src/Common/Common.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\..\config\versions.props" />
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/FreddysBBQ/src/Common/Models/Branding.cs
+++ b/FreddysBBQ/src/Common/Models/Branding.cs
@@ -1,8 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.ComponentModel.DataAnnotations;
-
-namespace Common.Models
+﻿namespace Common.Models
 {
     public class Branding
     {

--- a/FreddysBBQ/src/Common/Models/MenuItem.cs
+++ b/FreddysBBQ/src/Common/Models/MenuItem.cs
@@ -1,6 +1,6 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.ComponentModel.DataAnnotations;
+
 namespace Common.Models
 {
     public class MenuItem

--- a/FreddysBBQ/src/Common/Models/OrderItem.cs
+++ b/FreddysBBQ/src/Common/Models/OrderItem.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Common.Models

--- a/FreddysBBQ/src/Common/Services/AbstractService.cs
+++ b/FreddysBBQ/src/Common/Services/AbstractService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Steeltoe.Common.Discovery;
+using Steeltoe.Discovery;
 using System;
 using System.IO;
 using System.Net;
@@ -68,7 +69,7 @@ namespace Common.Services
 
                     _logger?.LogInformation(message);
 
-                    return default(T);
+                    return default;
                 }
 
                 Stream stream = await response.Content.ReadAsStreamAsync();
@@ -85,7 +86,7 @@ namespace Common.Services
                 if (response.StatusCode != HttpStatusCode.OK)
                 {
                     if (response.StatusCode == HttpStatusCode.NotFound)
-                        return default(T);
+                        return default;
 
                     // Log status
                     var message = string.Format("Service request returned status: {0} invoking path: {1}",
@@ -93,23 +94,23 @@ namespace Common.Services
 
                     _logger?.LogInformation(message);
 
-                    return default(T);
+                    return default;
                 }
 
                 string json = await response.Content.ReadAsStringAsync();
                 if (string.IsNullOrEmpty(json))
                 {
-                    return default(T);
+                    return default;
                 }
                 var parsed = JObject.Parse(json);
                 if (parsed == null)
                 {
-                    return default(T);
+                    return default;
                 }
                 var items = parsed["_embedded"]?[key];
                 if (items == null)
                 {
-                    return default(T);
+                    return default;
                 }
                 return items.ToObject<T>();
 

--- a/FreddysBBQ/src/Common/Services/IMenuService.cs
+++ b/FreddysBBQ/src/Common/Services/IMenuService.cs
@@ -1,7 +1,5 @@
 ﻿using Common.Models;
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Common.Services

--- a/FreddysBBQ/src/Common/Services/MenuService.cs
+++ b/FreddysBBQ/src/Common/Services/MenuService.cs
@@ -2,7 +2,7 @@
 using Common.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Steeltoe.Common.Discovery;
+using Steeltoe.Discovery;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/FreddysBBQ/src/Common/Services/MenuService.cs
+++ b/FreddysBBQ/src/Common/Services/MenuService.cs
@@ -1,5 +1,4 @@
-﻿
-using Common.Models;
+﻿using Common.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Discovery;

--- a/FreddysBBQ/src/Common/Services/OrderService.cs
+++ b/FreddysBBQ/src/Common/Services/OrderService.cs
@@ -1,7 +1,7 @@
 ﻿using Common.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Steeltoe.Common.Discovery;
+using Steeltoe.Discovery;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;

--- a/FreddysBBQ/src/OrderService/Models/OrderContext.cs
+++ b/FreddysBBQ/src/OrderService/Models/OrderContext.cs
@@ -1,5 +1,4 @@
-﻿
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using Common.Models;
 
 namespace OrderService.Models

--- a/FreddysBBQ/src/OrderService/OrderService.csproj
+++ b/FreddysBBQ/src/OrderService/OrderService.csproj
@@ -6,8 +6,6 @@
 
   <ItemGroup>
     <Folder Include="wwwroot\" />
-    <Compile Include="..\Common\Services\*.cs" />
-    <Compile Include="..\Common\Models\*.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
@@ -30,5 +28,9 @@
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Management.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Common\Common.csproj" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/OrderService/OrderService.csproj
+++ b/FreddysBBQ/src/OrderService/OrderService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\config\versions.props" />
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,17 +10,21 @@
     <Compile Include="..\Common\Models\*.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeDiscoveryVersion)" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeConfigVersion)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />
-    <PackageReference Include="Steeltoe.CloudFoundry.Connector.EFCore" Version="$(SteeltoeConnectorVersion)" />
-    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeLoggingVersion)" />
-    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeSecurityVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Steeltoe.Connector.EFCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/OrderService/OrderService.csproj
+++ b/FreddysBBQ/src/OrderService/OrderService.csproj
@@ -19,12 +19,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.EFCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Logging.DynamicLogger" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Management.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />
   </ItemGroup>
 </Project>

--- a/FreddysBBQ/src/OrderService/Program.cs
+++ b/FreddysBBQ/src/OrderService/Program.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Hosting;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 using Steeltoe.Extensions.Logging;

--- a/FreddysBBQ/src/OrderService/Program.cs
+++ b/FreddysBBQ/src/OrderService/Program.cs
@@ -17,13 +17,7 @@ namespace OrderService
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .AddCloudFoundryConfiguration()
-                .ConfigureLogging((builderContext, logging) =>
-                {
-                    logging.AddConfiguration(builderContext.Configuration.GetSection("Logging"));
-                    logging.AddDynamicConsole();
-                    logging.AddConsole();
-                    logging.AddDebug();
-                })
+                .AddDynamicLogging()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/FreddysBBQ/src/OrderService/Program.cs
+++ b/FreddysBBQ/src/OrderService/Program.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Hosting;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
+using Steeltoe.Discovery.Client;
 using Steeltoe.Extensions.Logging;
 
 namespace OrderService
@@ -11,19 +13,23 @@ namespace OrderService
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-                WebHost.CreateDefaultBuilder(args)
-                        .UseCloudHosting()
-                        .AddCloudFoundryConfiguration()
-                        .ConfigureLogging((builderContext, loggingBuilder) =>
-                        {
-                            loggingBuilder.AddConfiguration(builderContext.Configuration.GetSection("Logging"));
-                            loggingBuilder.AddDynamicConsole();
-                        })
-                        .UseStartup<Startup>()
-                        .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                /// .UseCloudHosting(5000)
+                // .AddCloudFoundryConfiguration()
+                .ConfigureLogging((builderContext, logging) =>
+                {
+                    logging.AddConfiguration(builderContext.Configuration.GetSection("Logging"));
+                    logging.AddDynamicConsole();
+                    logging.AddConsole();
+                    logging.AddDebug();
+                })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/FreddysBBQ/src/OrderService/Program.cs
+++ b/FreddysBBQ/src/OrderService/Program.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Hosting;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
-using Steeltoe.Discovery.Client;
 using Steeltoe.Extensions.Logging;
 
 namespace OrderService
@@ -18,8 +16,7 @@ namespace OrderService
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-                /// .UseCloudHosting(5000)
-                // .AddCloudFoundryConfiguration()
+                .AddCloudFoundryConfiguration()
                 .ConfigureLogging((builderContext, logging) =>
                 {
                     logging.AddConfiguration(builderContext.Configuration.GetSection("Logging"));
@@ -30,6 +27,7 @@ namespace OrderService
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
-                });
+                })
+                .UseCloudHosting();
     }
 }

--- a/FreddysBBQ/src/OrderService/Startup.cs
+++ b/FreddysBBQ/src/OrderService/Startup.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using OrderService.Models;
 using Steeltoe.Discovery.Client;
 using Steeltoe.CloudFoundry.Connector.MySql.EFCore;

--- a/FreddysBBQ/src/OrderService/Startup.cs
+++ b/FreddysBBQ/src/OrderService/Startup.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using OrderService.Models;
 using Steeltoe.Discovery.Client;
-using Steeltoe.CloudFoundry.Connector.MySql.EFCore;
 using Steeltoe.Security.Authentication.CloudFoundry;
 using Steeltoe.Connector.MySql.EFCore;
 
@@ -42,23 +41,17 @@ namespace OrderService
 
             services.AddSingleton<IMenuService, MenuService>();
 
-            // Add framework services.
-            services.AddMvc();
+            services.AddControllers();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            // loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            // loggerFactory.AddDebug();
-
             app.UseAuthentication();
 
             app.UseEndpoints(endpoints =>
             {
-                endpoints.MapControllerRoute(
-                    name: "default",
-                    pattern: "{controller=Home}/{action=Index}/{id?}");
+                endpoints.MapControllers();
             });
 
             app.UseDiscoveryClient();

--- a/FreddysBBQ/src/OrderService/Startup.cs
+++ b/FreddysBBQ/src/OrderService/Startup.cs
@@ -10,6 +10,7 @@ using OrderService.Models;
 using Steeltoe.Discovery.Client;
 using Steeltoe.CloudFoundry.Connector.MySql.EFCore;
 using Steeltoe.Security.Authentication.CloudFoundry;
+using Steeltoe.Connector.MySql.EFCore;
 
 namespace OrderService
 {
@@ -49,12 +50,17 @@ namespace OrderService
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            loggerFactory.AddConsole(Configuration.GetSection("Logging"));
-            loggerFactory.AddDebug();
+            // loggerFactory.AddConsole(Configuration.GetSection("Logging"));
+            // loggerFactory.AddDebug();
 
             app.UseAuthentication();
 
-            app.UseMvc();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
 
             app.UseDiscoveryClient();
 


### PR DESCRIPTION
The purpose of this pull request is to provide updates to the target framework for the Freddy's BBQ sample (.NET Core 2.1 -> .NET Core 3.1 and .NET 5.0)

Summary: 

- Updated AdminPortal/OrderService projects to target frameworks 3.1 & 5.0
- Use current package version build variable from version.props $(SteeltoeVersion) 