### PR TITLE
Add RabbitHost to Samples

### DIFF
--- a/Messaging/src/Console/DependencyInjection/DependencyInjection.csproj
+++ b/Messaging/src/Console/DependencyInjection/DependencyInjection.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/DependencyInjection/Program.cs
+++ b/Messaging/src/Console/DependencyInjection/Program.cs
@@ -3,66 +3,46 @@ using Steeltoe.Messaging.RabbitMQ.Config;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace ConsoleSendReceive
 {
     class Program
     {
-        private static ServiceProvider container;
-
         static void Main(string[] args)
         {
-            container = CreateServiceContainer();
-            var admin = container.GetRabbitAdmin();
-            var template = container.GetRabbitTemplate();
-            try
-            {
-                template.ConvertAndSend("myqueue", "foo");
-                var foo = template.ReceiveAndConvert<string>("myqueue");
-                Console.WriteLine(foo);
-            }
-            finally
-            {
-                // Delete queue and shutdown container
-                admin.DeleteQueue("myqueue");
-                container.Dispose();
-            }
-        }
+            var hostBuilder = RabbitHost.CreateDefaultBuilder();
 
-        private static ServiceProvider CreateServiceContainer()
-        {
-            var services = new ServiceCollection();
+            hostBuilder.ConfigureServices((hostbuilderContext, services) => {
+                services.AddLogging(b =>
+                {
+                    b.SetMinimumLevel(LogLevel.Information);
+                    b.AddDebug();
+                    b.AddConsole();
+                });
 
-            // Add some logging
-            services.AddLogging(b =>
-            {
-                b.SetMinimumLevel(LogLevel.Information);
-                b.AddDebug();
-                b.AddConsole();
+                // Add queue to be declared
+                services.AddRabbitQueue(new Queue("myqueue"));
             });
 
-            // Add any configuration as needed
-            var config = new ConfigurationBuilder().Build();
+            using (var host = hostBuilder.Start())
+            {
+                var admin = host.Services.GetRabbitAdmin();
+                var template = host.Services.GetRabbitTemplate();
 
-            // Configure any rabbit options from configuration
-            var rabbitSection = config.GetSection(RabbitOptions.PREFIX);
-            services.Configure<RabbitOptions>(rabbitSection);
-            services.AddSingleton<IConfiguration>(config);
-
-            // Add Steeltoe Rabbit services
-            services.AddRabbitServices();
-            services.AddRabbitAdmin();
-            services.AddRabbitTemplate();
-
-            // Add queue to be declared
-            services.AddRabbitQueue(new Queue("myqueue"));
-
-            // Build container and start
-            var provider = services.BuildServiceProvider();
-            provider.GetRequiredService<IHostedService>().StartAsync(default).Wait();
-            return provider;
+                try
+                {
+                    template.ConvertAndSend("myqueue", "foo");
+                    var foo = template.ReceiveAndConvert<string>("myqueue");
+                    Console.WriteLine(foo);
+                }
+                finally
+                {
+                    // Delete queue and shutdown container
+                    admin.DeleteQueue("myqueue");
+                }
+            }
         }
     }
 }

--- a/Messaging/src/Console/GenericHostEndpointManualContainer/GenericHostEndpointManualContainer.csproj
+++ b/Messaging/src/Console/GenericHostEndpointManualContainer/GenericHostEndpointManualContainer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/GenericHostEndpointManualContainer/Program.cs
+++ b/Messaging/src/Console/GenericHostEndpointManualContainer/Program.cs
@@ -1,13 +1,11 @@
-﻿using System;
-using ConsoleGenericHost;
+﻿using ConsoleGenericHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Contexts;
-using Steeltoe.Common.Lifecycle;
 using Steeltoe.Messaging.RabbitMQ.Config;
-using Steeltoe.Messaging.RabbitMQ.Connection;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
+using Steeltoe.Messaging.RabbitMQ.Host;
 using Steeltoe.Messaging.RabbitMQ.Listener;
 
 namespace ConsoleSendReceive
@@ -16,46 +14,31 @@ namespace ConsoleSendReceive
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+            CreatHostBuilder(args).Build().Run();
         }
 
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-            .ConfigureServices((hostContext, services) =>
-            {
-                // Add core services
-                services.AddRabbitHostingServices();
-                services.AddRabbitDefaultMessageConverter();
-                services.AddRabbitConnectionFactory();
-                services.AddRabbitListenerContainerFactory();
+        public static IHostBuilder CreatHostBuilder(string[] args) =>
+            RabbitHost.CreateDefaultBuilder()
+                .ConfigureServices((hostBuilderContext, services) => {
+                    // Add queue to be declared
+                    services.AddRabbitQueue(new Queue("myqueue"));
 
-                // Add Rabbit admin for auto queue declare
-                services.AddRabbitAdmin();
+                    services.AddRabbitDirecListenerContainer((p) =>
+                    {
+                        var context = p.GetRequiredService<IApplicationContext>();
+                        var factory = p.GetRequiredService<IRabbitListenerContainerFactory>();
+                        var logFactory = p.GetRequiredService<ILoggerFactory>();
+                        var listener = new MyMessageListener(logFactory.CreateLogger<MyMessageListener>());
+                        var endpoint = new SimpleRabbitListenerEndpoint(context);
+                        endpoint.SetQueueNames("myqueue");
+                        endpoint.MessageListener = listener;
+                        var container = factory.CreateListenerContainer(endpoint) as DirectMessageListenerContainer;
+                        container.ServiceName = "manualContainer";
+                        return container;
+                    });
 
-                // Add Rabbit template for MyRabbitSender
-                services.AddRabbitTemplate();
-
-                // Add queue to be declared
-                services.AddRabbitQueue(new Queue("myqueue"));
-
-
-                services.AddRabbitDirecListenerContainer((p) =>
-                {
-                    var context = p.GetRequiredService<IApplicationContext>();
-                    var factory = p.GetRequiredService<IRabbitListenerContainerFactory>();
-                    var logFactory = p.GetRequiredService<ILoggerFactory>();
-                    var listener = new MyMessageListener(logFactory.CreateLogger<MyMessageListener>());
-                    var endpoint = new SimpleRabbitListenerEndpoint(context);
-                    endpoint.SetQueueNames("myqueue");
-                    endpoint.MessageListener = listener;
-                    var container = factory.CreateListenerContainer(endpoint) as DirectMessageListenerContainer;
-                    container.ServiceName = "manualContainer";
-                    return container;
+                    // Add a message sender
+                    services.AddSingleton<IHostedService, MyRabbitSender>();
                 });
-
-                // Add a message sender
-                services.AddSingleton<IHostedService, MyRabbitSender>();
-
-            });
     }
 }

--- a/Messaging/src/Console/GenericHostEndpointRegistration/GenericHostEndpointRegistration.csproj
+++ b/Messaging/src/Console/GenericHostEndpointRegistration/GenericHostEndpointRegistration.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/GenericHostEndpointRegistration/Program.cs
+++ b/Messaging/src/Console/GenericHostEndpointRegistration/Program.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using ConsoleGenericHost;
+﻿using ConsoleGenericHost;
 using GenericHostEndpointRegistration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Steeltoe.Common.Contexts;
-using Steeltoe.Common.Lifecycle;
 using Steeltoe.Messaging.RabbitMQ.Config;
-using Steeltoe.Messaging.RabbitMQ.Connection;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
-using Steeltoe.Messaging.RabbitMQ.Listener;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace ConsoleSendReceive
 {
@@ -21,27 +16,17 @@ namespace ConsoleSendReceive
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-            .ConfigureServices((hostContext, services) =>
-            {
-                // Add core services
-                services.AddRabbitServices();
+            RabbitHost.CreateDefaultBuilder()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    // Add queue to be declared
+                    services.AddRabbitQueue(new Queue("myqueue"));
 
-                // Add Rabbit admin for auto queue declare
-                services.AddRabbitAdmin();
+                    // Add a configurer to configure listener endpoint
+                    services.AddSingleton<IRabbitListenerConfigurer, MyRabbitEndpointConfigurer>();
 
-                // Add Rabbit template for MyRabbitSender
-                services.AddRabbitTemplate();
-
-                // Add queue to be declared
-                services.AddRabbitQueue(new Queue("myqueue"));
-
-                // Add a configurer to configure listener endpoint
-                services.AddSingleton<IRabbitListenerConfigurer, MyRabbitEndpointConfigurer>();
-
-                // Add a message sender
-                services.AddSingleton<IHostedService, MyRabbitSender>();
-
-            });
+                    // Add a message sender
+                    services.AddSingleton<IHostedService, MyRabbitSender>();
+                });
     }
 }

--- a/Messaging/src/Console/GenericHostManualContainer/GenericHostManualContainer.csproj
+++ b/Messaging/src/Console/GenericHostManualContainer/GenericHostManualContainer.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/GenericHostManualContainer/Program.cs
+++ b/Messaging/src/Console/GenericHostManualContainer/Program.cs
@@ -1,14 +1,10 @@
-﻿using System;
-using ConsoleGenericHost;
+﻿using ConsoleGenericHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Steeltoe.Common.Contexts;
-using Steeltoe.Common.Lifecycle;
 using Steeltoe.Messaging.RabbitMQ.Config;
-using Steeltoe.Messaging.RabbitMQ.Connection;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
-using Steeltoe.Messaging.RabbitMQ.Listener;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace ConsoleSendReceive
 {
@@ -20,34 +16,22 @@ namespace ConsoleSendReceive
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-            .ConfigureServices((hostContext, services) =>
-            {
-                // Add core services
-                services.AddRabbitHostingServices();
-                services.AddRabbitDefaultMessageConverter();
-                services.AddRabbitConnectionFactory();
-
-                // Add Rabbit admin for auto queue declare
-                services.AddRabbitAdmin();
-
-                // Add Rabbit template for MyRabbitSender
-                services.AddRabbitTemplate();
-
-                // Add queue to be declared
-                services.AddRabbitQueue(new Queue("myqueue"));
-
-                services.AddRabbitDirecListenerContainer("manualContainer", (p, container) =>
+            RabbitHost.CreateDefaultBuilder()
+                .ConfigureServices((hostContext, services) =>
                 {
-                    var logFactory = p.GetRequiredService<ILoggerFactory>();
-                    container.ApplicationContext = p.GetApplicationContext();
-                    container.SetQueueNames("myqueue");
-                    container.MessageListener = new MyMessageListener(logFactory.CreateLogger<MyMessageListener>());
+                    // Add queue to be declared
+                    services.AddRabbitQueue(new Queue("myqueue"));
+
+                    services.AddRabbitDirecListenerContainer("manualContainer", (p, container) =>
+                    {
+                        var logFactory = p.GetRequiredService<ILoggerFactory>();
+                        container.ApplicationContext = p.GetApplicationContext();
+                        container.SetQueueNames("myqueue");
+                        container.MessageListener = new MyMessageListener(logFactory.CreateLogger<MyMessageListener>());
+                    });
+
+                    // Add a message sender
+                    services.AddSingleton<IHostedService, MyRabbitSender>();
                 });
-
-                // Add a message sender
-                services.AddSingleton<IHostedService, MyRabbitSender>();
-
-            });
     }
 }

--- a/Messaging/src/Console/GenericHostRabbitListener/GenericHostRabbitListener.csproj
+++ b/Messaging/src/Console/GenericHostRabbitListener/GenericHostRabbitListener.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/GenericHostRabbitListener/Program.cs
+++ b/Messaging/src/Console/GenericHostRabbitListener/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Messaging.RabbitMQ.Config;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace ConsoleSendReceive
 {
@@ -15,27 +16,17 @@ namespace ConsoleSendReceive
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-            .ConfigureServices((hostContext, services) =>
-            {
-                // Add core services
-                services.AddRabbitServices();
+            RabbitHost.CreateDefaultBuilder()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    // Add queue to be declared
+                    services.AddRabbitQueue(new Queue("myqueue"));
 
-                // Add Rabbit admin
-                services.AddRabbitAdmin();
+                    // Add the rabbit listener
+                    services.AddSingleton<MyRabbitListener>();
+                    services.AddRabbitListeners<MyRabbitListener>();
 
-                // Add Rabbit template
-                services.AddRabbitTemplate();
-
-                // Add queue to be declared
-                services.AddRabbitQueue(new Queue("myqueue"));
-
-                // Add the rabbit listener
-                services.AddSingleton<MyRabbitListener>();
-                services.AddRabbitListeners<MyRabbitListener>();
-
-                services.AddSingleton<IHostedService, MyRabbitSender>();
-
-            });
+                    services.AddSingleton<IHostedService, MyRabbitSender>();
+                });
     }
 }

--- a/Messaging/src/Console/GenericHostRabbitListenerHeaders/GenericHostRabbitListenerHeaders.csproj
+++ b/Messaging/src/Console/GenericHostRabbitListenerHeaders/GenericHostRabbitListenerHeaders.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.6" />
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/Console/GenericHostRabbitListenerHeaders/Program.cs
+++ b/Messaging/src/Console/GenericHostRabbitListenerHeaders/Program.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using ConsoleGenericHost;
+﻿using ConsoleGenericHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Steeltoe.Messaging.RabbitMQ.Config;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace ConsoleSendReceive
 {
@@ -15,27 +15,17 @@ namespace ConsoleSendReceive
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-            .ConfigureServices((hostContext, services) =>
-            {
-                // Add core services
-                services.AddRabbitServices();
+            RabbitHost.CreateDefaultBuilder()
+                .ConfigureServices((hostContext, services) =>
+                {
+                    // Add queue to be declared
+                    services.AddRabbitQueue(new Queue("myqueue"));
 
-                // Add Rabbit admin
-                services.AddRabbitAdmin();
+                    // Add the rabbit listener
+                    services.AddSingleton<MyRabbitListener>();
+                    services.AddRabbitListeners<MyRabbitListener>();
 
-                // Add Rabbit template
-                services.AddRabbitTemplate();
-
-                // Add queue to be declared
-                services.AddRabbitQueue(new Queue("myqueue"));
-
-                // Add the rabbit listener
-                services.AddSingleton<MyRabbitListener>();
-                services.AddRabbitListeners<MyRabbitListener>();
-
-                services.AddSingleton<IHostedService, MyRabbitSender>();
-
-            });
+                    services.AddSingleton<IHostedService, MyRabbitSender>();
+                });
     }
 }

--- a/Messaging/src/RabbitMQWeb/Program.cs
+++ b/Messaging/src/RabbitMQWeb/Program.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
+using Steeltoe.Messaging.RabbitMQ.Host;
 
 namespace RabbitMQWeb
 {
@@ -17,7 +12,7 @@ namespace RabbitMQWeb
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
+            RabbitHost.CreateDefaultBuilder()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/Messaging/src/RabbitMQWeb/RabbitMQWeb.csproj
+++ b/Messaging/src/RabbitMQWeb/RabbitMQWeb.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.0.0" />
+    <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="3.1.0-rc2" />
   </ItemGroup>
 
 </Project>

--- a/Messaging/src/RabbitMQWeb/Startup.cs
+++ b/Messaging/src/RabbitMQWeb/Startup.cs
@@ -23,23 +23,10 @@ namespace RabbitMQWeb
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // Configure any rabbit client values;
-            var rabbitSection = Configuration.GetSection(RabbitOptions.PREFIX);
-            services.Configure<RabbitOptions>(rabbitSection);
-
-            // Add steeltoe rabbit services
-            services.AddRabbitServices();
-            
-            // Add the steeltoe rabbit admin client... will be used to declare queues below
-            services.AddRabbitAdmin();
-
             // Add some queues to the container that the rabbit admin will discover and declare at startup
             services.AddRabbitQueue(new Queue(RabbitListenerService.INFERRED_FOO_QUEUE));
             services.AddRabbitQueue(new Queue(RabbitListenerService.INFERRED_BAR_QUEUE));
             services.AddRabbitQueue(new Queue(RECEIVE_AND_CONVERT_QUEUE));
-
-            // Add the rabbit client template used for send and receiving messages... used in RabbitTestController
-            services.AddRabbitTemplate();
 
             // Add singleton that will process incoming messages
             services.AddSingleton<RabbitListenerService>();


### PR DESCRIPTION
Adding RabbitHost to remove boilerplate setup

Note:  Command line args will be passed into `RabbitHost.CreateDefaultBuilder` after [PR #692: RabbitHost CreateDefaultBuilder Command Line Args](https://github.com/SteeltoeOSS/Steeltoe/pull/692) has been released in 3.1.0