### PR TITLE
Use Steeltoe 2.5.5, drop .NET Core 2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,8 +22,8 @@ A clear and concise description of what you expected to happen.
  - Sample name: [e.g. RabbitMQ Connector, Discovery, etc.]
  - Platform: [e.g. Cloud Foundry, Azure, etc.) 
  - OS: [e.g. Windows, Linux, Mac OSX]
- - .NET Version [e.g. .NET Core 2.1.0, .NET Framework 4.7.1, etc.] 
- - Steeltoe Version [e.g. 2.3.0]
+ - .NET Version [e.g. .NET Core 3.1.0, .NET Framework 4.7.1, etc.] 
+ - Steeltoe Version [e.g. 2.5.0]
  - Any other library versions to note
 
 ## Screenshots

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/Fortune-Teller-Service.csproj
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/Fortune-Teller-Service.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,14 +14,7 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/README.md
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/README.md
@@ -12,7 +12,7 @@ Refer to [common tasks](/CommonTasks.md#Spring-Cloud-Eureka-Server) for detailed
 
 1. Clone this repository. (`git clone https://github.com/SteeltoeOSS/Samples`)
 1. `cd samples/CircuitBreaker/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-Service`
-1. `dotnet run -f netcoreapp2.1`
+1. `dotnet run -f netcoreapp3.1`
 
 ## What to expect - Local
 
@@ -20,7 +20,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/CircuitBreaker/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-Service
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 info: Microsoft.Data.Entity.Storage.Internal.InMemoryStore[1]
       Saved 50 entities to in-memory store.
 Hosting environment: Production
@@ -34,7 +34,7 @@ At this point the Fortune Teller Service is up and waiting for the Fortune Telle
 
 1. Installed Pivotal CloudFoundry
 1. Installed Spring Cloud Services
-1. Install .Net Core SDK 2.1.300+
+1. Install .Net Core SDK
 
 ### Setup Service Registry on CloudFoundry
 
@@ -45,10 +45,10 @@ Using the service instance name of `myDiscoveryService`, complete the [common ta
 1. Login and target your desired space/org: `cf target -o myorg -s myspace`
 1. `cd samples/CircuitBreaker/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-Service`
 1. Publish the app, selecting the framework and runtime you want to run on:
-   - `dotnet publish -f netcoreapp2.1 -r linux-x64`
+   - `dotnet publish -f netcoreapp3.1 -r linux-x64`
 1. Push the app using the appropriate manifest:
-   - `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+   - `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 ## What to expect - CloudFoundry
 

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/Startup.cs
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/Startup.cs
@@ -27,11 +27,7 @@ namespace FortuneTellerService
             services.AddSingleton<IFortuneRepository, FortuneRepository>();
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllers();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -39,17 +35,8 @@ namespace FortuneTellerService
         {
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
 
             SampleData.InitializeFortunesAsync(app.ApplicationServices).Wait();
         }

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/nuget.config
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-Service/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/Fortune-Teller-UI.csproj
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/Fortune-Teller-UI.csproj
@@ -1,22 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.1|AnyCPU'">
-    <DefineConstants>TRACE;DEBUG;NETCOREAPP2_1</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/README.md
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/README.md
@@ -14,7 +14,7 @@ This sample assumes that there is a running Spring Cloud Eureka Server on your m
 
 1. Refer to common steps for [running a local Eureka server](/CommonTasks.md#Spring-Cloud-Eureka-Server)
 1. Refer to common steps for [running a local Hystrix dashboard](/CommonTasks.md#Hystrix-Dashboard)
-1. Install .Net Core SDK 2.1.300+
+1. Install .Net Core SDK
 
 ### Building & Running - Local
 
@@ -23,7 +23,7 @@ This sample assumes that there is a running Spring Cloud Eureka Server on your m
 1. Set the `BUILD` environment variable to `LOCAL` (i.e. SET BUILD=LOCAL, export BUILD=LOCAL)
 1. Set PORT to listen on (i.e SET PORT=5555, export PORT=5555)
 1. `dotnet restore`
-1. `dotnet run -f netcoreapp2.1`
+1. `dotnet run -f netcoreapp3.1`
 
 ### What to expect - Local
 
@@ -31,7 +31,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/CircuitBreaker/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-UI
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 Hosting environment: Production
 Now listening on: http://*:5555
 Application started. Press Ctrl+C to shut down.
@@ -54,7 +54,7 @@ Once you have the two applications communicating, you use of the Hystrix dashboa
 
 1. Installed Pivotal CloudFoundry
 1. Installed Spring Cloud Services
-1. Install .NET Core SDK 2.1+
+1. Install .NET Core SDK
 
 ### Setup Service Registry on CloudFoundry
 
@@ -70,8 +70,8 @@ Using the service instance name of `myHystrixService`, complete the [common task
 1. cd samples/CircuitBreaker/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-UI
 1. Make sure environment variable `BUILD` is not set to `LOCAL` (i.e. SET BUILD=, unset BUILD)
 1. `dotnet restore`
-1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.1 -r linux-x64`)
-1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp3.1 -r linux-x64`)
+1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 ### What to expect - CloudFoundry
 

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/Startup.cs
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/Startup.cs
@@ -38,22 +38,14 @@ namespace Fortune_Teller_UI
             services.AddHystrixCollapser<IFortuneServiceCollapser, FortuneServiceCollapser>("FortuneServiceCollapser", Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
 
             // Add Hystrix metrics stream to enable monitoring
             services.AddHystrixMetricsStream(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
 
             if (env.IsDevelopment())
@@ -70,17 +62,8 @@ namespace Fortune_Teller_UI
             // Add Hystrix Metrics context to pipeline
             app.UseHystrixRequestContext();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
 
             // Startup Hystrix metrics stream
             app.UseHystrixMetricsStream();

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/nuget.config
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/Fortune-Teller-UI/nuget.config
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="HdrHistogram" value="https://ci.appveyor.com/nuget/hdrhistogram-net-7o4w2wn7lgf9" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/RunFortuneTeller.cmd
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/RunFortuneTeller.cmd
@@ -7,5 +7,5 @@ SET BUILD=
 :usage
 echo USAGE: 
 echo RunFortuneTeller [framework]
-echo framework - target framework to publish (e.g. net461, netcoreapp2.1)
+echo framework - target framework to publish (e.g. netcoreapp3.1)
 exit /b

--- a/CircuitBreaker/src/AspDotNetCore/FortuneTeller/RunFortuneTeller.sh
+++ b/CircuitBreaker/src/AspDotNetCore/FortuneTeller/RunFortuneTeller.sh
@@ -3,7 +3,7 @@ function printUsage()
 {
     echo "USAGE:" 
     echo "RunFortuneTeller [framework]"
-    echo "framework - target framework to publish (e.g. netcoreapp2.1)"
+    echo "framework - target framework to publish (e.g. netcoreapp3.1)"
     exit
 }
 #

--- a/CommonTasks.md
+++ b/CommonTasks.md
@@ -12,13 +12,13 @@ To start a config server backed by a folder on your local disk, start the docker
 
 ```bash
 # Note: Ensure Docker is configured to share host drive/volume so the mount below will work correctly!
-docker run --rm -ti -p 8888:8888 -v $PWD/steeltoe/config-repo:/config --name steeltoe-config steeltoeoss/configserver --spring.profiles.active=native
+docker run --rm -ti -p 8888:8888 -v $PWD/steeltoe/config-repo:/config --name steeltoe-config steeltoeoss/config-server --spring.profiles.active=native
 ```
 
 To start a config server backed by the spring cloud samples repo:
 
 ```bash
-docker run --rm -ti -p 8888:8888 --name steeltoe-config steeltoeoss/configserver
+docker run --rm -ti -p 8888:8888 --name steeltoe-config steeltoeoss/config-server
 ```
 
 ### Run SCCS with Java

--- a/Configuration/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeConfigVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeConfigVersion)" />
   </ItemGroup>

--- a/Configuration/src/AspDotNetCore/CloudFoundry/CloudFoundry.feature
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/CloudFoundry.feature
@@ -21,24 +21,6 @@ Feature: CloudFoundry Configuration
     When you get https://cloud.x.y.z/Home/CloudFoundry
     Then you should see "vcap:application:application_name = cloud"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: CloudFoundry Configuration (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app cloud is started
-    When you get https://cloud.x.y.z/Home/CloudFoundry
-    Then you should see "vcap:application:application_name = cloud"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: CloudFoundry Configuration (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app cloud is started
-    When you get https://cloud.x.y.z/Home/CloudFoundry
-    Then you should see "vcap:application:application_name = cloud"
-
   @net5.0
   @win10-x64
   Scenario: CloudFoundry Configuration (net5.0/win10-x64)
@@ -53,15 +35,6 @@ Feature: CloudFoundry Configuration
   Scenario: CloudFoundry Configuration (net5.0/linux-x64)
     When you run: dotnet publish -f net5.0 -r linux-x64
     And you run in the background: cf push -f manifest.yml -p bin/Debug/net5.0/linux-x64/publish
-    And you wait until CloudFoundry app cloud is started
-    When you get https://cloud.x.y.z/Home/CloudFoundry
-    Then you should see "vcap:application:application_name = cloud"
-
-  @net461
-  @win10-x64
-  Scenario: CloudFoundry Configuration (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
     And you wait until CloudFoundry app cloud is started
     When you get https://cloud.x.y.z/Home/CloudFoundry
     Then you should see "vcap:application:application_name = cloud"

--- a/Configuration/src/AspDotNetCore/CloudFoundry/README.md
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/README.md
@@ -7,7 +7,7 @@ This ASP.NET Core sample app illustrates how to use the [Steeltoe Cloud Foundry 
 ## Pre-requisites
 
 1. Installed Pivotal CloudFoundry
-1. .NET Core SDK 2.1.300
+1. .NET Core SDK
 
 ## Publish App & Push
 
@@ -15,10 +15,10 @@ This ASP.NET Core sample app illustrates how to use the [Steeltoe Cloud Foundry 
 1. `cd src/AspDotNetCore/CloudFoundry`
 1. `dotnet restore`
 1. Publish app to a directory selecting the framework and runtime you want to run on:
-   - `dotnet publish -f netcoreapp2.1 -r linux-x64`
+   - `dotnet publish -f netcoreapp3.1 -r linux-x64`
 1. Push the app using the appropriate manifest:
-   - `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+   - `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 ## What to expect
 

--- a/Configuration/src/AspDotNetCore/CloudFoundry/Startup.cs
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/Startup.cs
@@ -24,19 +24,11 @@ namespace CloudFoundry
             services.ConfigureCloudFoundryOptions(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -49,7 +41,6 @@ namespace CloudFoundry
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -57,14 +48,6 @@ namespace CloudFoundry
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Configuration/src/AspDotNetCore/CloudFoundry/manifest.yml
+++ b/Configuration/src/AspDotNetCore/CloudFoundry/manifest.yml
@@ -5,4 +5,4 @@ applications:
    - dotnet_core_buildpack
   memory: 128M
   env:
-    ASPNETCORE_ENVIRONMENT: development
+    ASPNETCORE_ENVIRONMENT: Development

--- a/Configuration/src/AspDotNetCore/Placeholder/Placeholder.csproj
+++ b/Configuration/src/AspDotNetCore/Placeholder/Placeholder.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceholderCore" Version="$(SteeltoeConfigVersion)" />

--- a/Configuration/src/AspDotNetCore/Placeholder/Startup.cs
+++ b/Configuration/src/AspDotNetCore/Placeholder/Startup.cs
@@ -18,11 +18,7 @@ namespace Placeholder
         public void ConfigureServices(IServiceCollection services)
         {
             services.Configure<SampleOptions>(Configuration);
-#if NETCOREAPP3_1
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -39,7 +35,6 @@ namespace Placeholder
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -47,14 +42,6 @@ namespace Placeholder
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Configuration/src/AspDotNetCore/RandomValue/RandomValue.csproj
+++ b/Configuration/src/AspDotNetCore/RandomValue/RandomValue.csproj
@@ -1,17 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Steeltoe.Extensions.Configuration.RandomValueBase" Version="$(SteeltoeConfigVersion)" />

--- a/Configuration/src/AspDotNetCore/RandomValue/Startup.cs
+++ b/Configuration/src/AspDotNetCore/RandomValue/Startup.cs
@@ -17,11 +17,7 @@ namespace RandomValue
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-#if NETCOREAPP3_1
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -38,7 +34,6 @@ namespace RandomValue
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -46,14 +41,6 @@ namespace RandomValue
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Configuration/src/AspDotNetCore/Simple/README.adoc
+++ b/Configuration/src/AspDotNetCore/Simple/README.adoc
@@ -47,7 +47,7 @@ $ mvn spring-boot:run
 
 ----
 $ dotnet restore
-$ dotnet run -f netcoreapp2.1   # alternatively, dotnet run -f net461
+$ dotnet run -f netcoreapp3.1   # alternatively, dotnet run -f net5.0
 ----
 
 == What to Expect
@@ -55,7 +55,7 @@ $ dotnet run -f netcoreapp2.1   # alternatively, dotnet run -f net461
 After building and running the app, you should see something like the following:
 
 ----
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 Using launch settings from ...
 Hosting environment: development
 Content root path: ....

--- a/Configuration/src/AspDotNetCore/Simple/Simple.csproj
+++ b/Configuration/src/AspDotNetCore/Simple/Simple.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.ConfigServerCore" Version="$(SteeltoeConfigVersion)" />
   </ItemGroup>
 </Project>

--- a/Configuration/src/AspDotNetCore/Simple/Simple.feature
+++ b/Configuration/src/AspDotNetCore/Simple/Simple.feature
@@ -16,32 +16,6 @@ Feature: Simple Configuration
     Then you should see "spring:cloud:config:name = foo"
     And you should see "spring:cloud:config:env = MyNetCoreEnv"
 
-  @netcoreapp2.1
-  Scenario: Simple Configuration (netcoreapp2.1)
-    When you run: git clone https://github.com/spring-cloud/spring-cloud-config
-    And you run: git -C spring-cloud-config checkout v2.1.4.RELEASE
-    And you run in the background: mvn -f spring-cloud-config/spring-cloud-config-server/pom.xml spring-boot:run
-    And you wait until process listening on port 8888
-    And you set env var ASPNETCORE_ENVIRONMENT to "MyNetCoreEnv"
-    And you run in the background: dotnet run -f netcoreapp2.1
-    And you wait until process listening on port 5000
-    When you get http://localhost:5000/Home/ConfigServerSettings
-    Then you should see "spring:cloud:config:name = foo"
-    And you should see "spring:cloud:config:env = MyNetCoreEnv"
-
-  @net461
-  Scenario: Simple Configuration (net461)
-    When you run: git clone https://github.com/spring-cloud/spring-cloud-config
-    And you run: git -C spring-cloud-config checkout v2.1.4.RELEASE
-    And you run in the background: mvn -f spring-cloud-config/spring-cloud-config-server/pom.xml spring-boot:run
-    And you wait until process listening on port 8888
-    And you set env var ASPNETCORE_ENVIRONMENT to "MyNetCoreEnv"
-    And you run in the background: dotnet run -f net461
-    And you wait until process listening on port 5000
-    When you get http://localhost:5000/Home/ConfigServerSettings
-    Then you should see "spring:cloud:config:name = foo"
-    And you should see "spring:cloud:config:env = MyNetCoreEnv"
-
   @net5.0
   Scenario: Simple Configuration (net5.0)
     When you run: git clone https://github.com/spring-cloud/spring-cloud-config

--- a/Configuration/src/AspDotNetCore/Simple/Startup.cs
+++ b/Configuration/src/AspDotNetCore/Simple/Startup.cs
@@ -39,11 +39,7 @@ namespace Simple
             services.AddConfiguration(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
 
             // Adds the configuration data POCO configured with data returned from the Spring Cloud Config Server
             services.Configure<ConfigServerData>(Configuration);
@@ -64,7 +60,6 @@ namespace Simple
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -72,15 +67,6 @@ namespace Simple
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
-
     }
 }

--- a/Configuration/src/AspDotNetCore/Simple/docker-compose.yml
+++ b/Configuration/src/AspDotNetCore/Simple/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.2'
 services:
   config:
-    image: "steeltoeoss/configserver:1.3"
+    image: "steeltoeoss/config-server"
     ports:
       - "8888:8888"

--- a/Configuration/src/AspDotNetCore/SimpleCloudFoundry/README.md
+++ b/Configuration/src/AspDotNetCore/SimpleCloudFoundry/README.md
@@ -8,7 +8,7 @@ ASP.NET Core sample app illustrating how to use [Config Server for Pivotal Cloud
 
 1. Installed Pivotal CloudFoundry
 1. Installed Spring Cloud Services
-1. .NET Core SDK 2.1.300+
+1. .NET Core SDK
 
 ## Setup Config Server
 
@@ -20,10 +20,10 @@ Refer to [common tasks](/CommonTasks.md#Spring-Cloud-Config-Server) for detailed
 1. `cd src/AspDotNetCore/SimpleCloudFoundry`
 1. `dotnet restore`
 1. Publish app to a directory selecting the framework and runtime you want to run on:
-    - `dotnet publish -f netcoreapp2.1 -r linux-x64`
+    - `dotnet publish -f netcoreapp3.1 -r linux-x64`
 1. Push the app using the appropriate manifest:
-    - `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+    - `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 ## What to expect
 

--- a/Configuration/src/AspDotNetCore/SimpleCloudFoundry/SimpleCloudFoundry.csproj
+++ b/Configuration/src/AspDotNetCore/SimpleCloudFoundry/SimpleCloudFoundry.csproj
@@ -1,18 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />

--- a/Configuration/src/AspDotNetCore/SimpleCloudFoundry/SimpleCloudFoundry.feature
+++ b/Configuration/src/AspDotNetCore/SimpleCloudFoundry/SimpleCloudFoundry.feature
@@ -21,24 +21,6 @@ Feature: Simple CloudFoundry Configuration
     When you get https://foo.x.y.z/Home/ConfigServerSettings
     Then you should see "spring:cloud:config:name = foo"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: Simple CloudFoundry Configuration (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app foo is started
-    When you get https://foo.x.y.z/Home/ConfigServerSettings
-    Then you should see "spring:cloud:config:name = foo"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: Simple CloudFoundry Configuration (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app foo is started
-    When you get https://foo.x.y.z/Home/ConfigServerSettings
-    Then you should see "spring:cloud:config:name = foo"
-
   @net5.0
   @win10-x64
   Scenario: Simple CloudFoundry Configuration (net5.0/win10-x64)
@@ -53,15 +35,6 @@ Feature: Simple CloudFoundry Configuration
   Scenario: Simple CloudFoundry Configuration (net5.0/linux-x64)
     When you run: dotnet publish -f net5.0 -r linux-x64
     And you run in the background: cf push -f manifest.yml -p bin/Debug/net5.0/linux-x64/publish
-    And you wait until CloudFoundry app foo is started
-    When you get https://foo.x.y.z/Home/ConfigServerSettings
-    Then you should see "spring:cloud:config:name = foo"
-
-  @net461
-  @win10-x64
-  Scenario: Simple CloudFoundry Configuration (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
     And you wait until CloudFoundry app foo is started
     When you get https://foo.x.y.z/Home/ConfigServerSettings
     Then you should see "spring:cloud:config:name = foo"

--- a/Configuration/src/AspDotNetCore/SimpleCloudFoundry/Startup.cs
+++ b/Configuration/src/AspDotNetCore/SimpleCloudFoundry/Startup.cs
@@ -34,11 +34,7 @@ namespace SimpleCloudFoundry
             // Adds the configuration data POCO configured with data returned from the Spring Cloud Config Server
             services.Configure<ConfigServerData>(Configuration);
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -59,7 +55,6 @@ namespace SimpleCloudFoundry
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -67,14 +62,6 @@ namespace SimpleCloudFoundry
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/MySql/MySql.csproj
+++ b/Connectors/src/AspDotNetCore/MySql/MySql.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="MySql.Data" Version="8.0.11" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />

--- a/Connectors/src/AspDotNetCore/MySql/MySql.feature
+++ b/Connectors/src/AspDotNetCore/MySql/MySql.feature
@@ -23,26 +23,6 @@ Feature: MySql Connector
     Then you should see "Key 1 = Row1 Text"
     And you should see "Key 2 = Row2 Text"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: MySql Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app mysql-connector is started
-    When you get https://mysql-connector.x.y.z/Home/MySqlData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: MySql Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app mysql-connector is started
-    When you get https://mysql-connector.x.y.z/Home/MySqlData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
   @net5.0
   @win10-x64
   Scenario: MySql Connector (net5.0/win10-x64)
@@ -58,16 +38,6 @@ Feature: MySql Connector
   Scenario: MySql Connector (net5.0/linux-x64)
     When you run: dotnet publish -f net5.0 -r linux-x64
     And you run in the background: cf push -f manifest.yml -p bin/Debug/net5.0/linux-x64/publish
-    And you wait until CloudFoundry app mysql-connector is started
-    When you get https://mysql-connector.x.y.z/Home/MySqlData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
-  @net461
-  @win10-x64
-  Scenario: MySql Connector (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
     And you wait until CloudFoundry app mysql-connector is started
     When you get https://mysql-connector.x.y.z/Home/MySqlData
     Then you should see "Key 1 = Row1 Text"

--- a/Connectors/src/AspDotNetCore/MySql/README.md
+++ b/Connectors/src/AspDotNetCore/MySql/README.md
@@ -34,11 +34,11 @@ You must first create an instance of the MySql service in a org/space.
 1. `cd samples/Connectors/src/AspDotNetCore/MySql`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f net5 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/net5/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `mysql-connector` and attempt to bind the app to MySql service `myMySqlService`.
 

--- a/Connectors/src/AspDotNetCore/MySql/Startup.cs
+++ b/Connectors/src/AspDotNetCore/MySql/Startup.cs
@@ -22,19 +22,11 @@ namespace MySql
             services.AddMySqlConnection(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, Microsoft.AspNetCore.Hosting.IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -47,7 +39,6 @@ namespace MySql
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -55,14 +46,6 @@ namespace MySql
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/MySqlEF6/MySqlEF6.csproj
+++ b/Connectors/src/AspDotNetCore/MySqlEF6/MySqlEF6.csproj
@@ -1,28 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net461;netcoreapp3.1;</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
     <MvcRazorExcludeRefAssembliesFromPublish>false</MvcRazorExcludeRefAssembliesFromPublish>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
-    <Content Remove="C:\Users\thess\.nuget\packages\mysql.data.entityframework\8.0.23\contentFiles\any\net452\app.config.transform" />
-    <Content Remove="C:\Users\thess\.nuget\packages\mysql.data.entityframework\8.0.23\contentFiles\any\net452\web.config.transform" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="MySql.Data.EntityFramework" Version="8.0.23" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeManagementVersion)" />

--- a/Connectors/src/AspDotNetCore/MySqlEF6/MySqlEF6.feature
+++ b/Connectors/src/AspDotNetCore/MySqlEF6/MySqlEF6.feature
@@ -3,16 +3,6 @@ Feature: MySqlEF6 Connector
   In order to show you how to use Steeltoe for connecting to MySql using EntityFramework 6
   You can run some MySql using EntityFramework 6 connection samples
 
-  @net461
-  @win10-x64
-  Scenario: MySqlEF6 Connector (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-    And you wait until CloudFoundry app mysqlef6-connector is started
-    When you get https://mysqlef6-connector.x.y.z/Home/MySqlData
-    Then you should see "Key 1 = Test Data 1"
-    And you should see "Key 2 = Test Data 2"
-
   @netcoreapp3.1
   @win10-x64
   Scenario: MySqlEF6 Connector (netcoreapp3.1/win10-x64)

--- a/Connectors/src/AspDotNetCore/MySqlEF6/README.md
+++ b/Connectors/src/AspDotNetCore/MySqlEF6/README.md
@@ -24,9 +24,9 @@ You must first create an instance of the MySql service in a org/space.
 1. `cd samples/Connectors/src/AspDotNetCore/MySqlEF6`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `mysqlef6-connector` and attempt to bind the app to MySql service `myMySqlService`.
 

--- a/Connectors/src/AspDotNetCore/MySqlEF6/Startup.cs
+++ b/Connectors/src/AspDotNetCore/MySqlEF6/Startup.cs
@@ -25,19 +25,11 @@ namespace MySqlEF6
             services.AddMySqlHealthContributor(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -50,17 +42,8 @@ namespace MySqlEF6
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/MySqlEFCore/MySqlEFCore.csproj
+++ b/Connectors/src/AspDotNetCore/MySqlEFCore/MySqlEFCore.csproj
@@ -1,27 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461;</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(AspNetCoreVersion)" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.Connector.EFCore" Version="$(SteeltoeConnectorVersion)" />

--- a/Connectors/src/AspDotNetCore/MySqlEFCore/MySqlEFCore.feature
+++ b/Connectors/src/AspDotNetCore/MySqlEFCore/MySqlEFCore.feature
@@ -23,26 +23,6 @@ Feature: MySqlEFCore Connector
     Then you should see "1: Test Data 1 - EF Core TestContext A"
     And you should see "2: Test Data 2 - EF Core TestContext B"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: MySqlEFCore Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app mysqlefcore-connector is started
-    When you get https://mysqlefcore-connector.x.y.z/Home/MySqlData
-    Then you should see "1: Test Data 1 - EF Core TestContext A"
-    And you should see "2: Test Data 2 - EF Core TestContext B"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: MySqlEFCore Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app mysqlefcore-connector is started
-    When you get https://mysqlefcore-connector.x.y.z/Home/MySqlData
-    Then you should see "1: Test Data 1 - EF Core TestContext A"
-    And you should see "2: Test Data 2 - EF Core TestContext B"
-
   @net5.0
   @win10-x64
   Scenario: MySqlEFCore Connector (net5.0/win10-x64)

--- a/Connectors/src/AspDotNetCore/MySqlEFCore/README.md
+++ b/Connectors/src/AspDotNetCore/MySqlEFCore/README.md
@@ -24,11 +24,11 @@ You must first create an instance of the MySql service in a org/space.
 1. `cd samples/Connectors/src/AspDotNetCore/MySqlEFCore`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `mysqlefcore-connector` and attempt to bind the app to MySql service `myMySqlService`.
 

--- a/Connectors/src/AspDotNetCore/MySqlEFCore/Startup.cs
+++ b/Connectors/src/AspDotNetCore/MySqlEFCore/Startup.cs
@@ -36,19 +36,11 @@ namespace MySqlEFCore
             }
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -61,17 +53,8 @@ namespace MySqlEFCore
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/OAuth/OAuth.csproj
+++ b/Connectors/src/AspDotNetCore/OAuth/OAuth.csproj
@@ -1,19 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />
     <PackageReference Include="Steeltoe.Management.CloudFoundryCore" Version="$(SteeltoeManagementVersion)" />

--- a/Connectors/src/AspDotNetCore/OAuth/README.md
+++ b/Connectors/src/AspDotNetCore/OAuth/README.md
@@ -24,11 +24,11 @@ If you want to use the [Pivotal Single Signon](https://docs.pivotal.io/p-identit
 1. `cd samples/Connectors/src/AspDotNetCore/OAuth`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest(s) will create an app named `oauth-connector` and attempt to bind the app to User Provided service `myOAuthService`.
 

--- a/Connectors/src/AspDotNetCore/OAuth/Startup.cs
+++ b/Connectors/src/AspDotNetCore/OAuth/Startup.cs
@@ -22,19 +22,11 @@ namespace OAuth
             // Configure and Add IOptions<OAuthServiceOptions> to the container
             services.AddOAuthServiceOptions(Configuration);
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -47,7 +39,6 @@ namespace OAuth
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -55,14 +46,6 @@ namespace OAuth
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/PostgreEFCore/PostgreEFCore.csproj
+++ b/Connectors/src/AspDotNetCore/PostgreEFCore/PostgreEFCore.csproj
@@ -1,22 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />

--- a/Connectors/src/AspDotNetCore/PostgreEFCore/PostgreEFCore.feature
+++ b/Connectors/src/AspDotNetCore/PostgreEFCore/PostgreEFCore.feature
@@ -23,26 +23,6 @@ Feature: PostgreEFCore Connector
     Then you should see "1: Test Data 1 - EF Core TestContext"
     And you should see "2: Test Data 2 - EF Core TestContext"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: PostgreEFCore Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app postgresefcore-connector is started
-    When you get https://postgresefcore-connector.x.y.z/Home/PostgresData
-    Then you should see "1: Test Data 1 - EF Core TestContext"
-    And you should see "2: Test Data 2 - EF Core TestContext"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: PostgreEFCore Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app postgresefcore-connector is started
-    When you get https://postgresefcore-connector.x.y.z/Home/PostgresData
-    Then you should see "1: Test Data 1 - EF Core TestContext"
-    And you should see "2: Test Data 2 - EF Core TestContext"
-
   @net5.0
   @win10-x64
   Scenario: PostgreEFCore Connector (net5.0/win10-x64)

--- a/Connectors/src/AspDotNetCore/PostgreEFCore/README.md
+++ b/Connectors/src/AspDotNetCore/PostgreEFCore/README.md
@@ -36,11 +36,11 @@ Create an instance of the PostgreSQL database service in a org/space:
 1. `cd samples/Connectors/src/AspDotNetCore/PostgreEFCore`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest(s) will create an app named `postgresefcore-connector` and attempt to bind the app to PostgreSql service `myPostgres`.
 

--- a/Connectors/src/AspDotNetCore/PostgreEFCore/Startup.cs
+++ b/Connectors/src/AspDotNetCore/PostgreEFCore/Startup.cs
@@ -22,19 +22,11 @@ namespace PostgreEFCore
             services.AddDbContext<TestContext>(options => options.UseNpgsql(Configuration));
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -47,7 +39,6 @@ namespace PostgreEFCore
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -55,14 +46,6 @@ namespace PostgreEFCore
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/PostgreSql/PostgreSql.csproj
+++ b/Connectors/src/AspDotNetCore/PostgreSql/PostgreSql.csproj
@@ -1,23 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Npgsql" Version="4.0.2" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />

--- a/Connectors/src/AspDotNetCore/PostgreSql/PostgreSql.feature
+++ b/Connectors/src/AspDotNetCore/PostgreSql/PostgreSql.feature
@@ -23,36 +23,6 @@ Feature: PostgreSql Connector
     Then you should see "Key 1 = Row1 Text"
     And you should see "Key 2 = Row2 Text"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: PostgreSql Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app postgres-connector is started
-    When you get https://postgres-connector.x.y.z/Home/PostgresData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: PostgreSql Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app postgres-connector is started
-    When you get https://postgres-connector.x.y.z/Home/PostgresData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
-  @net461
-  @win10-x64
-  Scenario: PostgreSql Connector (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-    And you wait until CloudFoundry app postgres-connector is started
-    When you get https://postgres-connector.x.y.z/Home/PostgresData
-    Then you should see "Key 1 = Row1 Text"
-    And you should see "Key 2 = Row2 Text"
-
   @net5.0
   @win10-x64
   Scenario: PostgreSql Connector (net5.0/win10-x64)

--- a/Connectors/src/AspDotNetCore/PostgreSql/README.md
+++ b/Connectors/src/AspDotNetCore/PostgreSql/README.md
@@ -36,11 +36,11 @@ cf create-service postgresql-10-odb standalone myPostgres -c '{\"db_name\":\"pos
 1. `cd samples/Connectors/src/AspDotNetCore/PostgreSql`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest(s) will create an app named `postgres-connector` and attempt to bind the app to PostgreSQL service `myPostgres`.
 

--- a/Connectors/src/AspDotNetCore/PostgreSql/Startup.cs
+++ b/Connectors/src/AspDotNetCore/PostgreSql/Startup.cs
@@ -22,19 +22,11 @@ namespace PostgreSql
             services.AddPostgresConnection(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -47,17 +39,8 @@ namespace PostgreSql
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
 
             // Insert couple rows into table
             SampleData.InitializePostgresData(app.ApplicationServices).GetAwaiter().GetResult();

--- a/Connectors/src/AspDotNetCore/RabbitMQ/README.md
+++ b/Connectors/src/AspDotNetCore/RabbitMQ/README.md
@@ -6,7 +6,7 @@ ASP.NET Core sample app illustrating how to use [Steeltoe RabbitMQ Connector](ht
 
 ## Pre-requisites - CloudFoundry
 
-1. Installed Pivotal CloudFoundry 1.7+
+1. Installed CloudFoundry
 1. (Optional) installed Windows support
 1. Installed RabbitMQ CloudFoundry service
 1. Installed .NET Core SDK
@@ -24,11 +24,11 @@ You must first create an instance of the RabbitMQ service in a org/space.
 1. `cd samples/Connectors/src/AspDotNetCore/RabbitMQ`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `rabbitmq-connector` and attempt to bind the app to RabbitMQ service `myRabbitMQService`.
 

--- a/Connectors/src/AspDotNetCore/RabbitMQ/RabbitMQ.csproj
+++ b/Connectors/src/AspDotNetCore/RabbitMQ/RabbitMQ.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitMQVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />

--- a/Connectors/src/AspDotNetCore/RabbitMQ/RabbitMQ.feature
+++ b/Connectors/src/AspDotNetCore/RabbitMQ/RabbitMQ.feature
@@ -23,36 +23,6 @@ Feature: RabbitMQ Connector
     And you get https://rabbitmq-connector.x.y.z/RabbitMQ/Receive
     Then you should see "Message=HEY THERE"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: Rabbit Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app rabbitmq-connector is started
-    When you post "Message=HEY THERE" to https://rabbitmq-connector.x.y.z/RabbitMQ/Send
-    And you get https://rabbitmq-connector.x.y.z/RabbitMQ/Receive
-    Then you should see "Message=HEY THERE"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: Rabbit Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app rabbitmq-connector is started
-    When you post "Message=HEY THERE" to https://rabbitmq-connector.x.y.z/RabbitMQ/Send
-    And you get https://rabbitmq-connector.x.y.z/RabbitMQ/Receive
-    Then you should see "Message=HEY THERE"
-
-  @net461
-  @win10-x64
-  Scenario: Rabbit Connector (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-    And you wait until CloudFoundry app rabbitmq-connector is started
-    When you post "Message=HEY THERE" to https://rabbitmq-connector.x.y.z/RabbitMQ/Send
-    And you get https://rabbitmq-connector.x.y.z/RabbitMQ/Receive
-    Then you should see "Message=HEY THERE"
-
   @net5.0
   @win10-x64
   Scenario: Rabbit Connector (net5.0/win10-x64)

--- a/Connectors/src/AspDotNetCore/RabbitMQ/Startup.cs
+++ b/Connectors/src/AspDotNetCore/RabbitMQ/Startup.cs
@@ -21,19 +21,11 @@ namespace RabbitMQ
         {
             services.AddRabbitMQConnection(Configuration);
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -46,7 +38,6 @@ namespace RabbitMQ
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -54,14 +45,6 @@ namespace RabbitMQ
                     name: "default",
                     pattern: "{controller=RabbitMQ}/{action=Send}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=RabbitMQ}/{action=Send}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Connectors/src/AspDotNetCore/Redis/README.md
+++ b/Connectors/src/AspDotNetCore/Redis/README.md
@@ -26,11 +26,11 @@ You must first create an instance of the Redis service in a org/space.
 1. `cd samples/Connectors/src/AspDotNetCore/Redis`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `redis-connector` and attempt to bind the app to Redis service `myRedisService`.
 

--- a/Connectors/src/AspDotNetCore/Redis/Redis.csproj
+++ b/Connectors/src/AspDotNetCore/Redis/Redis.csproj
@@ -1,25 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeConnectorVersion)" />
     <PackageReference Include="Steeltoe.Management.CloudFoundryCore" Version="$(SteeltoeManagementVersion)" />

--- a/Connectors/src/AspDotNetCore/Redis/Redis.feature
+++ b/Connectors/src/AspDotNetCore/Redis/Redis.feature
@@ -23,26 +23,6 @@ Feature: Redis Connector
     Then you should see "Key1=Key1Value"
     And you should see "Key2=Key2Value"
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: Redis Connector (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app redis-connector is started
-    When you get https://redis-connector.x.y.z/Home/CacheData
-    Then you should see "Key1=Key1Value"
-    And you should see "Key2=Key2Value"
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: Redis Connector (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app redis-connector is started
-    When you get https://redis-connector.x.y.z/Home/CacheData
-    Then you should see "Key1=Key1Value"
-    And you should see "Key2=Key2Value"
-
   @net5.0
   @win10-x64
   Scenario: Redis Connector (net5.0/win10-x64)
@@ -58,16 +38,6 @@ Feature: Redis Connector
   Scenario: Redis Connector (net5.0/linux-x64)
     When you run: dotnet publish -f net5.0 -r linux-x64
     And you run in the background: cf push -f manifest.yml -p bin/Debug/net5.0/linux-x64/publish
-    And you wait until CloudFoundry app redis-connector is started
-    When you get https://redis-connector.x.y.z/Home/CacheData
-    Then you should see "Key1=Key1Value"
-    And you should see "Key2=Key2Value"
-
-  @net461
-  @win10-x64
-  Scenario: Redis Connector (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
     And you wait until CloudFoundry app redis-connector is started
     When you get https://redis-connector.x.y.z/Home/CacheData
     Then you should see "Key1=Key1Value"

--- a/Connectors/src/AspDotNetCore/Redis/Startup.cs
+++ b/Connectors/src/AspDotNetCore/Redis/Startup.cs
@@ -31,19 +31,11 @@ namespace Redis
             services.AddRedisConnectionMultiplexer(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -56,17 +48,8 @@ namespace Redis
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
 
             // Add some data to the Redis cache
             SampleData.InitializeCache(app.ApplicationServices).Wait();

--- a/Connectors/src/AspDotNetCore/SqlServerEFCore/README.md
+++ b/Connectors/src/AspDotNetCore/SqlServerEFCore/README.md
@@ -27,11 +27,11 @@ You must first create an instance of the SQL Server service in a org/space using
 1. `cd samples/Connectors/src/AspDotNetCore/SqlServerEFCore`
 1. `dotnet restore --configfile nuget.config`
 1. Publish app to a local directory, specifying the framework and runtime (select ONE of these commands):
-   * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-   * `dotnet publish -f net461 -r win10-x64`
+   * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+   * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest (select ONE of these commands):
-   * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-   * `cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish`
+   * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+   * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `sqlserverefcore-connector` and attempt to bind the app to SQL Server service `mySqlServerService`.
 

--- a/Connectors/src/AspDotNetCore/SqlServerEFCore/SqlServerEFCore.csproj
+++ b/Connectors/src/AspDotNetCore/SqlServerEFCore/SqlServerEFCore.csproj
@@ -1,21 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.Connector.EFCore" Version="$(SteeltoeConnectorVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeConfigVersion)" />

--- a/Connectors/src/AspDotNetCore/SqlServerEFCore/Startup.cs
+++ b/Connectors/src/AspDotNetCore/SqlServerEFCore/Startup.cs
@@ -21,19 +21,11 @@ namespace SqlServerEFCore
             // Add Context and use SqlServer as provider ... provider will be configured from VCAP_ info
             services.AddDbContext<TestContext>(options => options.UseSqlServer(Configuration));
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -46,17 +38,8 @@ namespace SqlServerEFCore
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-Service/Fortune-Teller-Service.csproj
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-Service/Fortune-Teller-Service.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,16 +14,9 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-Service/README.md
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-Service/README.md
@@ -20,7 +20,7 @@ This sample assumes that there is a running Spring Cloud Eureka Server on your m
 1. Clone this repo. (i.e. git clone <https://github.com/SteeltoeOSS/Samples>)
 1. cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-Service
 1. dotnet restore --configfile nuget.config
-1. dotnet run -f netcoreapp2.1
+1. dotnet run -f netcoreapp3.1
 
 ## What to expect - Local
 
@@ -28,7 +28,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-Service
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 info: Microsoft.Data.Entity.Storage.Internal.InMemoryStore[1]
       Saved 50 entities to in-memory store.
 Hosting environment: Production
@@ -57,9 +57,9 @@ You must first create an instance of the Service Registry service in a org/space
 
 1. cf target -o myorg -s development
 1. cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-Service
-1. dotnet restore --configfile nuget.config
-1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.1 -r linux-x64`)
-1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+1. dotnet restore
+1. Publish app to a directory selecting the runtime you want to run on. (e.g. `dotnet publish -r linux-x64`)
+1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 > Note: If you are using self-signed certificates it is possible that you might run into SSL certificate validation issues when pushing this app. The simplest way to fix this:
 

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-Service/Startup.cs
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-Service/Startup.cs
@@ -28,11 +28,7 @@ namespace FortuneTellerService
             services.AddSingleton<IFortuneRepository, FortuneRepository>();
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllers();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -41,17 +37,8 @@ namespace FortuneTellerService
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
 
             SampleData.InitializeFortunesAsync(app.ApplicationServices).Wait();
         }

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-Service/nuget.config
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-Service/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-Service/versions.props
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-Service/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SteeltoeVersion>2.4.3</SteeltoeVersion>
+    <SteeltoeVersion>2.5.5</SteeltoeVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SteeltoeCommonVersion>$(SteeltoeVersion)</SteeltoeCommonVersion>
@@ -14,14 +14,6 @@
     <GitInfoVersion>2.0.20</GitInfoVersion>
     <JsonNetVersion>11.0.3</JsonNetVersion>
 	  <RabbitMQVersion>5.1.0</RabbitMQVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
-    <AspNetCoreVersion>2.1.1</AspNetCoreVersion>
-    <EFCoreVersion>2.1.1</EFCoreVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <AspNetCoreVersion>2.1.1</AspNetCoreVersion>
-    <EFCoreVersion>2.1.1</EFCoreVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
       <AspNetCoreVersion>3.1.0</AspNetCoreVersion>

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-UI/Fortune-Teller-UI.csproj
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-UI/Fortune-Teller-UI.csproj
@@ -1,18 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-UI/README.md
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-UI/README.md
@@ -13,7 +13,7 @@ Refer to [common tasks](/CommonTasks.md#Spring-Cloud-Eureka-Server) for detailed
 1. Clone this repository: `git clone https://github.com/SteeltoeOSS/Samples`
 1. `cd samples/Discovery/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-UI`
 1. `dotnet restore`
-1. `dotnet run -f netcoreapp3.1` - netcoreapp2.1 are also valid choices net461
+1. `dotnet run`
 
 ## What to expect - Local
 
@@ -21,7 +21,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-UI
-$ dotnet run -f netcoreapp2.1
+$ dotnet run
 Hosting environment: Production
 Now listening on: http://*:5555
 Application started. Press Ctrl+C to shut down.
@@ -39,8 +39,9 @@ Using the service instance name of `myDiscoveryService`, complete the [common ta
 
 1. Login and target your desired space/org: `cf target -o myorg -s myspace`
 1. `cd samples/Discovery/src/AspDotNetCore/Fortune-Teller/Fortune-Teller-Service`
-1. Publish the app, selecting the framework and runtime you want to run on:
-   - `dotnet publish -f netcoreapp3.1 -r linux-x64`
+1. Publish the app, selecting the runtime you want to run on:
+   - `dotnet publish -r linux-x64`
+   - `dotnet publish -r win10-x64`
 1. Push the app using the appropriate manifest:
    - `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
    - `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-UI/Startup.cs
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-UI/Startup.cs
@@ -29,19 +29,11 @@ namespace Fortune_Teller_UI
                 .AddTypedClient<IFortuneService, FortuneService>();
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -54,17 +46,8 @@ namespace Fortune_Teller_UI
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Discovery/src/AspDotNetCore/Fortune-Teller-UI/nuget.config
+++ b/Discovery/src/AspDotNetCore/Fortune-Teller-UI/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Discovery/src/AspDotNetCore/RunFortuneTeller.cmd
+++ b/Discovery/src/AspDotNetCore/RunFortuneTeller.cmd
@@ -5,5 +5,5 @@ start "Fortune Teller UI" dotnet run -p .\Fortune-Teller-UI\Fortune-Teller-UI.cs
 :usage
 echo USAGE: 
 echo RunFortuneTeller [framework]
-echo framework - target framework to publish (e.g. net461, netcoreapp2.1)
+echo framework - target framework to publish (e.g. netcoreapp3.1)
 exit /b

--- a/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj
+++ b/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.csproj
@@ -1,18 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
 
   <ItemGroup>
     <!-- GitInfo provides $(Git*) properties used below -->
@@ -28,12 +18,7 @@
     <PackageReference Include="Steeltoe.Management.CloudFoundryCore" Version="$(SteeltoeManagementVersion)" />
     <PackageReference Include="Steeltoe.Management.ExporterCore" Version="$(SteeltoeManagementVersion)" />
     <PackageReference Include="Steeltoe.Management.TaskCore" Version="$(SteeltoeManagementVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.2" />
   </ItemGroup>
   <ItemGroup>
     <None Include="git.properties" CopyToOutputDirectory="PreserveNewest" />

--- a/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.feature
+++ b/Management/src/AspDotNetCore/CloudFoundry/CloudFoundry.feature
@@ -19,30 +19,6 @@ Feature: Cloud Foundry Samples
     And you wait until CloudFoundry app actuator is started
     Then you should be able to access CloudFoundry app actuator management endpoints
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: CloudFoundry Management (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app actuator is started
-    Then you should be able to access CloudFoundry app actuator management endpoints
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: CloudFoundry Management (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app actuator is started
-    Then you should be able to access CloudFoundry app actuator management endpoints
-
-  @net461
-  @win10-x64
-  Scenario: CloudFoundry Management (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-    And you wait until CloudFoundry app actuator is started
-    Then you should be able to access CloudFoundry app actuator management endpoints
-
   @net5.0
   @win10-x64
   Scenario: CloudFoundry Management (net5.0/win10-x64)

--- a/Management/src/AspDotNetCore/CloudFoundry/README.md
+++ b/Management/src/AspDotNetCore/CloudFoundry/README.md
@@ -26,9 +26,9 @@ You must first create an instance of the MySql service in a org/space.
 
 1. cf target -o myorg -s development
 2. cd samples/Management/src/AspDotNetCore/CloudFoundry
-3. dotnet restore --configfile nuget.config
-4. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.2 -r linux-x64`)
-5. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.2/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.2/win10-x64/publish`)
+3. dotnet restore
+4. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp3.1 -r linux-x64`)
+5. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 > Note: The provided manifest will create an app named `actuator` and attempt to bind to the the app to MySql service `myMySqlService`.
 

--- a/Management/src/AspDotNetCore/CloudFoundry/Startup.cs
+++ b/Management/src/AspDotNetCore/CloudFoundry/Startup.cs
@@ -45,19 +45,11 @@ namespace CloudFoundry
             // services.AddMetricsForwarderExporter(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -73,17 +65,8 @@ namespace CloudFoundry
             // Add metrics collection to the app
             // Remove comment below to enable
             // app.UseMetricsActuator();
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
             // Start up the metrics forwarder service added above
             // Remove comment below to enable
             // app.UseMetricsExporter();

--- a/Management/src/AspDotNetCore/CloudFoundry/nuget.config
+++ b/Management/src/AspDotNetCore/CloudFoundry/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Management/src/AspDotNetCore/MicrosoftHealthChecks/MicrosoftHealthChecks.csproj
+++ b/Management/src/AspDotNetCore/MicrosoftHealthChecks/MicrosoftHealthChecks.csproj
@@ -1,16 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props"/>
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net461;</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
     <!-- GitInfo provides $(Git*) properties used below -->
     <PackageReference Include="AspNetCore.HealthChecks.MySql" Version="2.2.0" />

--- a/Management/src/AspDotNetCore/MicrosoftHealthChecks/README.md
+++ b/Management/src/AspDotNetCore/MicrosoftHealthChecks/README.md
@@ -24,9 +24,9 @@ You must first create an instance of the MySql service in a org/space.
 
 1. cf target -o myorg -s development
 2. cd samples/Management/src/AspDotNetCore/CloudFoundry
-3. dotnet restore --configfile nuget.config
-4. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.1 -r linux-x64`)
-5. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+3. dotnet restore
+4. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp3.1 -r linux-x64`)
+5. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 > Note: The provided manifest will create an app named `actuator` and attempt to bind to the the app to MySql service `myMySqlService`.
 

--- a/Management/src/AspDotNetCore/MicrosoftHealthChecks/Startup.cs
+++ b/Management/src/AspDotNetCore/MicrosoftHealthChecks/Startup.cs
@@ -32,19 +32,11 @@ namespace CloudFoundry
             services.AddHealthChecksUI();
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -67,17 +59,8 @@ namespace CloudFoundry
             //Optionally use health checks ui at /healthchecks-ui
             app.UseHealthChecksUI();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Management/src/AspDotNetCore/MicrosoftHealthChecks/nuget.config
+++ b/Management/src/AspDotNetCore/MicrosoftHealthChecks/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/Fortune-Teller-Service.csproj
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/Fortune-Teller-Service.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,16 +13,10 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/README.md
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/README.md
@@ -40,7 +40,7 @@ If you have a running docker environment installed on your system, then you shou
 
 1. Clone this repository. (i.e. git clone <https://github.com/SteeltoeOSS/Samples>)
 1. cd samples/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service
-1. dotnet run -f netcoreapp2.1
+1. dotnet run -f netcoreapp3.1
 
 ## What to expect - Locally
 
@@ -48,7 +48,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 info: Microsoft.Data.Entity.Storage.Internal.InMemoryStore[1]
       Saved 50 entities to in-memory store.
 Hosting environment: Production
@@ -87,8 +87,8 @@ You must first create an instance of the Service Registry service in a org/space
 
 1. cf target -o myorg -s development
 1. cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-Service
-1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.1 -r linux-x64`)
-1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp3.1 -r linux-x64`)
+1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 ## What to expect - CloudFoundry
 

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/Startup.cs
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/Startup.cs
@@ -32,11 +32,7 @@ namespace FortuneTellerService
             services.AddZipkinExporter(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllers();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -44,12 +40,8 @@ namespace FortuneTellerService
         {
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc();
-#endif
 
             // Start up trace exporter
             app.UseTracingExporter();

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/nuget.config
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-Service/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/Fortune-Teller-UI.csproj
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/Fortune-Teller-UI.csproj
@@ -1,14 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Discovery.ClientCore" Version="$(SteeltoeVersion)" />

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/README.md
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/README.md
@@ -14,7 +14,7 @@ Note: You can run all of this either locally or on CloudFoundry.
 
 1. Clone this repository. (i.e. git clone <https://github.com/SteeltoeOSS/Samples>)
 1. cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-UI
-1. dotnet run -f netcoreapp2.1
+1. dotnet run -f netcoreapp3.1
 
 ## What to expect - Locally
 
@@ -22,7 +22,7 @@ After building and running the app, you should see something like the following:
 
 ```bash
 $ cd samples/Discovery/src/AspDotNetCore/Fortune-Teller-UI
-$ dotnet run -f netcoreapp2.1
+$ dotnet run -f netcoreapp3.1
 Hosting environment: Production
 Now listening on: http://*:5555
 Application started. Press Ctrl+C to shut down.
@@ -46,8 +46,8 @@ Before proceeding with the steps below, make sure you have completed the steps t
 
 1. cf target -o myorg -s development
 1. cd samples/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI
-1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp2.1 -r linux-x64`)
-1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+1. Publish app to a directory selecting the framework and runtime you want to run on. (e.g. `dotnet publish -f netcoreapp3.1 -r linux-x64`)
+1. Push the app using the appropriate manifest. (e.g. `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish` or `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 ## What to expect - CloudFoundry
 

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/Startup.cs
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/Startup.cs
@@ -36,19 +36,11 @@ namespace Fortune_Teller_UI
             services.AddZipkinExporter(Configuration);
 
             // Add framework services.
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -61,12 +53,8 @@ namespace Fortune_Teller_UI
 
             app.UseStaticFiles();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapDefaultControllerRoute());
-#else
-            app.UseMvc();
-#endif
 
             // Start up trace exporter
             app.UseTracingExporter();

--- a/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/nuget.config
+++ b/Management/src/AspDotNetCore/Tracing/Fortune-Teller-UI/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Management/src/AspDotNetCore/Tracing/RunTracing.cmd
+++ b/Management/src/AspDotNetCore/Tracing/RunTracing.cmd
@@ -5,5 +5,5 @@ start "Fortune Teller UI" dotnet run -p .\Fortune-Teller-UI\Fortune-Teller-UI.cs
 :usage
 echo USAGE: 
 echo RunFortuneTeller [framework]
-echo framework - target framework to publish (e.g. net461, netcoreapp2.1)
+echo framework - target framework to publish (e.g. netcoreapp3.1)
 exit /b

--- a/Management/src/AspDotNetCore/Tracing/RunTracing.sh
+++ b/Management/src/AspDotNetCore/Tracing/RunTracing.sh
@@ -3,7 +3,7 @@ function printUsage()
 {
     echo "USAGE:" 
     echo "RunFortuneTeller [framework]"
-    echo "framework - target framework to publish (e.g. netcoreapp2.1)"
+    echo "framework - target framework to publish (e.g. netcoreapp3.1)"
     exit
 }
 #

--- a/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/CloudFoundryJwtAuthentication.csproj
+++ b/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/CloudFoundryJwtAuthentication.csproj
@@ -1,21 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/README.md
+++ b/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/README.md
@@ -14,13 +14,13 @@ This sample illustrates how you can secure your web api endpoints using JWT Bear
 
 1. cf target -o myorg -s development
 1. cd samples/Security/src/CloudFoundryJwtAuthentication
-1. dotnet restore --configfile nuget.config
+1. dotnet restore
 1. Publish app to a directory selecting the framework and runtime you want to run on.
-    * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-    * `dotnet publish -f netcoreapp2.1 -r win10-x64`
+    * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+    * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest.
-    * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`)
+    * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`)
 
 The provided manifest(s) will create an app named `jwtauth` and attempt to bind it to `myOAuthService`.
 

--- a/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/Startup.cs
+++ b/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/Startup.cs
@@ -30,23 +30,12 @@ namespace CloudFoundryJwtAuthentication
                 options.AddPolicy("testgroup1", policy => policy.RequireClaim("scope", "testgroup1"));
             });
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
-
-
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
@@ -56,15 +45,6 @@ namespace CloudFoundryJwtAuthentication
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseAuthentication();
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/nuget.config
+++ b/Security/src/AspDotNetCore/CloudFoundryJwtAuthentication/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/CloudFoundrySingleSignon.csproj
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/CloudFoundrySingleSignon.csproj
@@ -1,21 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)|$(OS)' == 'net461|Unix'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.Authentication.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/CloudFoundrySingleSignon.feature
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/CloudFoundrySingleSignon.feature
@@ -33,51 +33,6 @@ Feature: CloudFoundry Single SignOn
     Then you should be at https://single-signon.x.y.z/Home/About
     And you should see "Your About page."
 
-  @netcoreapp2.1
-  @win10-x64
-  Scenario: CloudFoundry Single SignOn (netcoreapp2.1/win10-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish
-    And you wait until CloudFoundry app single-signon is started
-    When you get https://single-signon.x.y.z/Home/About
-    Then you should be at https://uaa.x.y.z/login
-    When you login with "baduser"/"badpass"
-    Then you should be at https://uaa.x.y.z/login
-    And you should see "Unable to verify email or password. Please try again."
-    When you login with "testuser"/"Password1!"
-    Then you should be at https://single-signon.x.y.z/Home/About
-    And you should see "Your About page."
-
-  @netcoreapp2.1
-  @linux-x64
-  Scenario: CloudFoundry Single SignOn (netcoreapp2.1/linux-x64)
-    When you run: dotnet publish -f netcoreapp2.1 -r linux-x64
-    And you run in the background: cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish
-    And you wait until CloudFoundry app single-signon is started
-    When you get https://single-signon.x.y.z/Home/About
-    Then you should be at https://uaa.x.y.z/login
-    When you login with "baduser"/"badpass"
-    Then you should be at https://uaa.x.y.z/login
-    And you should see "Unable to verify email or password. Please try again."
-    When you login with "testuser"/"Password1!"
-    Then you should be at https://single-signon.x.y.z/Home/About
-    And you should see "Your About page."
-
-  @net461
-  @win10-x64
-  Scenario: CloudFoundry Single SignOn (net461/win10-x64)
-    When you run: dotnet publish -f net461 -r win10-x64
-    And you run in the background: cf push -f manifest-windows.yml -p bin/Debug/net461/win10-x64/publish
-    And you wait until CloudFoundry app single-signon is started
-    When you get https://single-signon.x.y.z/Home/About
-    Then you should be at https://uaa.x.y.z/login
-    When you login with "baduser"/"badpass"
-    Then you should be at https://uaa.x.y.z/login
-    And you should see "Unable to verify email or password. Please try again."
-    When you login with "testuser"/"Password1!"
-    Then you should be at https://single-signon.x.y.z/Home/About
-    And you should see "Your About page."
-
   @net5.0
   @win10-x64
   Scenario: CloudFoundry Single SignOn (net5.0/win10-x64)

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/README-SSO.md
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/README-SSO.md
@@ -30,11 +30,11 @@ Next, locate the sso-setup script you'd like to execute (.cmd/.sh) from the scri
 1. cd samples/Security/src/CloudFoundrySingleSignon
 1. dotnet restore --configfile nuget.config
 1. Publish app to a directory, specifying the desired framework and runtime:
-    * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-    * `dotnet publish -f netcoreapp2.1 -r win10-x64`
+    * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+    * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest:
-    * `cf push -f manifest-sso.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    * `cf push -f manifest-windows-sso.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+    * `cf push -f manifest-sso.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    * `cf push -f manifest-windows-sso.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest(s) will create an app named `single-signon` and attempt to bind it to the SSO service `mySSOService`.
 

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/README.md
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/README.md
@@ -58,13 +58,13 @@ cf cups myOAuthService -p "{\"client_id\": \"myTestApp\",\"client_secret\": \"my
 
 1. cf target -o myorg -s development
 1. cd samples/Security/src/CloudFoundrySingleSignon
-1. dotnet restore --configfile nuget.config
+1. dotnet restore
 1. Publish app to a directory selecting the framework and runtime you want to run on.
-    * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-    * `dotnet publish -f netcoreapp2.1 -r win10-x64`
+    * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+    * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest.
-    * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+    * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest(s) will create an app named `single-signon` and attempt to bind it to the user-provided service `myOAuthService`.
 

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/Startup.cs
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/Startup.cs
@@ -55,19 +55,11 @@ namespace CloudFoundrySingleSignon
             // services.AddDistributedRedisCache(Configuration);
             // services.AddSession();
 
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -85,7 +77,6 @@ namespace CloudFoundrySingleSignon
                 ForwardedHeaders = ForwardedHeaders.XForwardedProto
             });
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
@@ -95,15 +86,6 @@ namespace CloudFoundrySingleSignon
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseAuthentication();
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Security/src/AspDotNetCore/CloudFoundrySingleSignon/nuget.config
+++ b/Security/src/AspDotNetCore/CloudFoundrySingleSignon/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/Security/src/AspDotNetCore/CredHubDemo/CredHubDemo.csproj
+++ b/Security/src/AspDotNetCore/CredHubDemo/CredHubDemo.csproj
@@ -1,17 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />

--- a/Security/src/AspDotNetCore/CredHubDemo/README.md
+++ b/Security/src/AspDotNetCore/CredHubDemo/README.md
@@ -23,12 +23,12 @@ We will need to use the UAA command line tool to establish some security credent
 1. cd samples/Security/src/CredHubDemo
 1. dotnet restore
 1. Publish app to a directory selecting the framework and runtime you want to run on.
-    * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-    * `dotnet publish -f netcoreapp2.1 -r win10-x64`
+    * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+    * `dotnet publish -f netcoreapp3.1 -r win10-x64`
     * `dotnet publish -f net461 -r win10-x64`
 1. Push the app using the appropriate manifest.
-    * `cf push -f manifest-nix.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    * `cf push -f manifest-win-core.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+    * `cf push -f manifest-nix.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    * `cf push -f manifest-win-core.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
     * `cf push -f manifest-win.yml -p bin/Debug/net461/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `CredHubDemo-nix`, `CredHubDemo-win` or `CredHubDemo-wincore`.

--- a/Security/src/AspDotNetCore/CredHubDemo/Startup.cs
+++ b/Security/src/AspDotNetCore/CredHubDemo/Startup.cs
@@ -27,19 +27,11 @@ namespace CredHubDemo
             services.AddCloudFoundryActuators(Configuration);
             services.Configure<CredHubOptions>(Configuration.GetSection("CredHubClient"));
             services.AddCredHubClient(Configuration, logFactory);
-#if NETCOREAPP3_1 || NET5_0
             services.AddControllersWithViews();
-#else
-            services.AddMvc();
-#endif
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NETCOREAPP3_1 || NET5_0
         public void Configure(IApplicationBuilder app, IHostEnvironment env)
-#else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-#endif
         {
             if (env.IsDevelopment())
             {
@@ -53,7 +45,6 @@ namespace CredHubDemo
             app.UseStaticFiles();
             app.UseCloudFoundryActuators();
 
-#if NETCOREAPP3_1 || NET5_0
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {
@@ -61,14 +52,6 @@ namespace CredHubDemo
                     name: "default",
                     pattern: "{controller=Home}/{action=Index}/{id?}");
             });
-#else
-            app.UseMvc(routes =>
-            {
-                routes.MapRoute(
-                    name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
-            });
-#endif
         }
     }
 }

--- a/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/README.md
+++ b/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/README.md
@@ -20,13 +20,13 @@ You must first create an instance of the Redis service in a org/space.
 
 1. cf target -o myorg -s development
 1. cd samples/Security/src/RedisDataProtectionKeyStore
-1. dotnet restore --configfile nuget.config
+1. dotnet restore
 1. Publish app to a directory, specifying the desired framework and runtime:
-    * `dotnet publish -f netcoreapp2.1 -r linux-x64`
-    * `dotnet publish -f netcoreapp2.1 -r win10-x64`
+    * `dotnet publish -f netcoreapp3.1 -r linux-x64`
+    * `dotnet publish -f netcoreapp3.1 -r win10-x64`
 1. Push the app using the appropriate manifest:
-    * `cf push -f manifest.yml -p bin/Debug/netcoreapp2.1/linux-x64/publish`
-    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp2.1/win10-x64/publish`
+    * `cf push -f manifest.yml -p bin/Debug/netcoreapp3.1/linux-x64/publish`
+    * `cf push -f manifest-windows.yml -p bin/Debug/netcoreapp3.1/win10-x64/publish`
 
 > Note: The provided manifest will create an app named `keystore` and attempt to bind to the Redis service `myRedisService`.
 

--- a/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/RedisDataProtectionKeyStore.csproj
+++ b/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/RedisDataProtectionKeyStore.csproj
@@ -1,22 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <Import Project="..\..\..\..\config\versions.props" />
-  <Import Project="..\..\..\..\config\targetframework.props" />
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.Session" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(AspNetCoreVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
-  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(AspNetCoreVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.CloudFoundry.ConnectorCore" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Security.DataProtection.RedisCore" Version="$(SteeltoeVersion)" />

--- a/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/nuget.config
+++ b/Security/src/AspDotNetCore/RedisDataProtectionKeyStore/nuget.config
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="SteeltoeDev" value="https://www.myget.org/F/steeltoedev/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>

--- a/TESTS.md
+++ b/TESTS.md
@@ -37,7 +37,7 @@ C:> .\behave.ps1 Connectors\src\AspDotNetCore\RabbitMQ
 To run only a specific framework/runtime combination, use the `--tags` or `-t` parameter:
 
 ```dos
-C:> .\behave.ps1 Connectors\src\AspDotNetCore\RabbitMQ -t netcoreapp2.1 -t linux-x64
+C:> .\behave.ps1 Connectors\src\AspDotNetCore\RabbitMQ -t netcoreapp3.1 -t linux-x64
 ```
 
 ## Configuring

--- a/ci/templates/setup-tools-steps.yaml
+++ b/ci/templates/setup-tools-steps.yaml
@@ -1,6 +1,5 @@
 parameters:
   dotnet3Version: 3.1.x
-  dotnet2Version: 2.1.x
   dotnet5Version: 5.0.x
 steps:
 - task: UseDotNet@2
@@ -8,11 +7,6 @@ steps:
   inputs:
     packageType: sdk
     version: ${{parameters.dotnet3Version}}
-- task: UseDotNet@2
-  displayName: 'Setup DotNet2'
-  inputs:
-    packageType: sdk
-    version: ${{parameters.dotnet2Version}}
 - task: UseDotNet@2
   displayName: 'Setup DotNet5'
   inputs:

--- a/config/versions.props
+++ b/config/versions.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <SteeltoeVersion>2.5.3</SteeltoeVersion>
+    <SteeltoeVersion>2.5.5</SteeltoeVersion>
   </PropertyGroup>
   <PropertyGroup>
     <SteeltoeCommonVersion>$(SteeltoeVersion)</SteeltoeCommonVersion>


### PR DESCRIPTION
Update Steeltoe version via version.props (PR does not touch ASP.NET 4x samples)
Remove netcoreapp2.1 and net461 from most ASP.NET Core samples #221
- samples skipped haven't been made to work on netcoreapp3.1 yet, might be deleted (and referred to `main`) rather than updated