### PR TITLE
Update SMBFileShares to .Net core 3.1, 6

### DIFF
--- a/FileShares/src/NetworkFileShares.sln
+++ b/FileShares/src/NetworkFileShares.sln
@@ -7,8 +7,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SMBFileShares", "SMBFileSha
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33343C0D-E396-458D-9235-8D1311B8CAB3}"
 	ProjectSection(SolutionItems) = preProject
-		..\..\scripts\cf-create-service.ps1 = ..\..\scripts\cf-create-service.ps1
-		..\..\scripts\create-user-and-share.ps1 = ..\..\scripts\create-user-and-share.ps1
+		..\scripts\cf-create-service.ps1 = ..\scripts\cf-create-service.ps1
+		..\scripts\create-user-and-share.ps1 = ..\scripts\create-user-and-share.ps1
+		..\..\configure.ps1 = ..\..\configure.ps1
 	EndProjectSection
 EndProject
 Global

--- a/FileShares/src/SMBFileShares/Directory.Build.props
+++ b/FileShares/src/SMBFileShares/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <SteeltoeVersion>3.1.2</SteeltoeVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <GitInfoVersion>2.0.20</GitInfoVersion>
+    <JsonNetVersion>11.0.3</JsonNetVersion>
+    <RabbitMQVersion>6.2.2</RabbitMQVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <AspNetCoreVersion>3.1.0</AspNetCoreVersion>
+    <EFCoreVersion>3.1.0</EFCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <AspNetCoreVersion>5.0.0</AspNetCoreVersion>
+    <EFCoreVersion>5.0.0</EFCoreVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <AspNetCoreVersion>6.0.0</AspNetCoreVersion>
+    <EFCoreVersion>6.0.0</EFCoreVersion>
+  </PropertyGroup>
+</Project>

--- a/FileShares/src/SMBFileShares/Pages/Index.cshtml
+++ b/FileShares/src/SMBFileShares/Pages/Index.cshtml
@@ -1,5 +1,5 @@
 ﻿@page
-@model SMBFileShares.Controllers.IndexModel
+@model SMBFileShares.Pages.IndexModel
 @{
 }
 <h1>Windows File Shares</h1>

--- a/FileShares/src/SMBFileShares/Pages/Index.cshtml.cs
+++ b/FileShares/src/SMBFileShares/Pages/Index.cshtml.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
-namespace SMBFileShares.Controllers
+namespace SMBFileShares.Pages
 {
     public class IndexModel : PageModel
     {

--- a/FileShares/src/SMBFileShares/Program.cs
+++ b/FileShares/src/SMBFileShares/Program.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
 using Steeltoe.Common.Hosting;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 
@@ -9,13 +9,16 @@ namespace SMBFileShares
     {
         public static void Main(string[] args)
         {
-            CreateWebHostBuilder(args).Build().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .ConfigureAppConfiguration(cfg => cfg.AddCloudFoundry())
-                .UseCloudHosting()
-                .UseStartup<Startup>();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .AddCloudFoundryConfiguration()
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                })
+                .UseCloudHosting();
     }
 }

--- a/FileShares/src/SMBFileShares/SMBFileShares.csproj
+++ b/FileShares/src/SMBFileShares/SMBFileShares.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,16 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
-    <PackageReference Include="Microsoft.AspNetCore.HttpsPolicy" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Steeltoe.Common.Hosting" Version="2.4.3" />
-    <PackageReference Include="Steeltoe.Common.Net" Version="2.4.3" />
-    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="2.4.3" />
+    <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Common.Net" Version="$(SteeltoeVersion)" />
+    <PackageReference Include="Steeltoe.Extensions.Configuration.CloudFoundryCore" Version="$(SteeltoeVersion)" />
   </ItemGroup>
 
 </Project>

--- a/FileShares/src/SMBFileShares/Startup.cs
+++ b/FileShares/src/SMBFileShares/Startup.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Steeltoe.Extensions.Configuration.CloudFoundry;
 
 namespace SMBFileShares
@@ -21,18 +21,25 @@ namespace SMBFileShares
         {
             // Add Steeltoe Cloud Foundry Options to service container
             services.ConfigureCloudFoundryOptions(Configuration);
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+            services.AddRazorPages();
+            services.AddControllersWithViews();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseStaticFiles();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapDefaultControllerRoute();
+                endpoints.MapRazorPages();
+            });
         }
     }
 }


### PR DESCRIPTION
* fix links to scripts
* use props file

This is the part of https://github.com/SteeltoeOSS/Samples/issues/221

There is only WorkshopFinal sample left with target to core 2.2.