### PR TITLE
Fix: deduce UAA/SingleSignon URLs SSO tests

### DIFF
--- a/Security/src/CloudFoundrySingleSignon/scaffold/cloudfoundry.py
+++ b/Security/src/CloudFoundrySingleSignon/scaffold/cloudfoundry.py
@@ -11,40 +11,45 @@ def setup(context):
     :type context: behave.runner.Context
     """
     cf = cloudfoundry.CloudFoundry(context)
-    # remove previous apps
-    cf.delete_app('single-signon')
-    # cf.delete_app('uaa')
-    # create UAA service and app
-    if not cf.service_exists('myOAuthService'):
-        credentials = '\'{{"client_id":"myTestApp", "client_secret":"myTestApp", "uri":"{}"}}\''.format(
-            dns.resolve_url(context, 'uaa://uaa'))
-        cf.create_user_provided_service('myOAuthService', credentials)
+    domain = 'apps.{}'.format(context.options.cf.apiurl.removeprefix('https://api.sys.'))
+    oauth = 'myOAuthService'
     uaa = 'uaa'
-    if not cf.app_exists(uaa):
-        fqdn = dns.resolve_hostname(context, uaa)
-        domain = fqdn.removeprefix("{}.".format(uaa))
-        uaa_repo = os.path.join(context.project_dir, uaa)
-        if os.path.exists(uaa_repo):
-            def remove_readonly(func, path, excinfo):
-                os.chmod(path, stat.S_IWRITE)
-                func(path)
-            shutil.rmtree(uaa_repo, onerror=remove_readonly)
-        for cmd_s in [
-            'git clone https://github.com/cloudfoundry/uaa.git',
-            'git -C uaa checkout 4.7.1',
-            'uaa/gradlew -p uaa -Dapp={} -Dapp-domain={} manifests -Dorg.gradle.daemon=false'.format(uaa,
-                                                                                                     domain),
-        ]:
-            Command(context, cmd_s).run()
-        cf.push_app('uaa/build/sample-manifests/uaa-cf-application.yml')
-        for cmd_s in [
-            'uaac target {}'.format(dns.resolve_url(context, 'https://uaa')),
-            'uaac token client get admin -s adminsecret',
-            'uaac contexts',
-            'uaac group add testgroup',
-            'uaac user add testuser --given_name Test --family_name User --emails testuser@domain.com --password Password1!',
-            'uaac member add testgroup testuser',
-            'uaac client add myTestApp --scope cloud_controller.read,cloud_controller_service_permissions.read,openid,testgroup --authorized_grant_types authorization_code,refresh_token --authorities uaa.resource --redirect_uri {} --autoapprove cloud_controller.read,cloud_controller_service_permissions.read,openid,testgroup --secret myTestApp'.format(
-                'https://single-signon/signin-cloudfoundry'),
-        ]:
-            Command(context, cmd_s).run()
+    uaa_url = 'uaa://{}.{}'.format(uaa, domain)
+    sso = 'single-signon'
+    sso_url = 'https://{}.{}'.format(sso, domain)
+    # remove previous apps
+    cf.delete_app(sso)
+    cf.delete_app(uaa)
+    # remove previous services
+    cf.delete_service(oauth)
+    # create UAA service
+    credentials = '\'{{"client_id":"myTestApp", "client_secret":"myTestApp", "uri":"{}"}}\''.format(uaa_url)
+    cf.create_user_provided_service(oauth, credentials)
+    # create UAA app
+    uaa_repo = os.path.join(context.project_dir, uaa)
+    if os.path.exists(uaa_repo):
+        def remove_readonly(func, path, excinfo):
+            os.chmod(path, stat.S_IWRITE)
+            func(path)
+
+        shutil.rmtree(uaa_repo, onerror=remove_readonly)
+    for cmd_s in [
+        'git clone https://github.com/cloudfoundry/uaa.git',
+        'git -C uaa checkout 4.7.1',
+        'uaa/gradlew -p uaa -Dapp={} -Dapp-domain={} manifests -Dorg.gradle.daemon=false'.format(uaa,
+                                                                                                 domain),
+    ]:
+        Command(context, cmd_s).run()
+    cf.push_app('uaa/build/sample-manifests/uaa-cf-application.yml')
+    # configure UAA app
+    for cmd_s in [
+        'uaac target {}'.format(dns.resolve_url(context, 'https://uaa')),
+        'uaac token client get admin -s adminsecret',
+        'uaac contexts',
+        'uaac group add testgroup',
+        'uaac user add testuser --given_name Test --family_name User --emails testuser@domain.com --password Password1!',
+        'uaac member add testgroup testuser',
+        'uaac client add myTestApp --scope cloud_controller.read,cloud_controller_service_permissions.read,openid,testgroup --authorized_grant_types authorization_code,refresh_token --authorities uaa.resource --redirect_uri {}/signin-cloudfoundry --autoapprove cloud_controller.read,cloud_controller_service_permissions.read,openid,testgroup --secret myTestApp'.format(
+            sso_url),
+    ]:
+        Command(context, cmd_s).run()

--- a/pysteel/cloudfoundry.py
+++ b/pysteel/cloudfoundry.py
@@ -11,6 +11,10 @@ class CloudFoundryObjectDoesNotExistError(Exception):
     pass
 
 
+class CloudFoundryRouteError(Exception):
+    pass
+
+
 class CloudFoundry(object):
 
     def __init__(self, context):
@@ -207,6 +211,8 @@ class CloudFoundry(object):
         except command.CommandException as e:
             if "App '{}' not found".format(app_name) in str(e):
                 raise CloudFoundryObjectDoesNotExistError()
+            if "Requested route" in str(e) and "does not exist" in str(e):
+                raise CloudFoundryRouteError()
             raise e
         match = re.search(r'^#0\s+(\S+)', cmd.stdout, re.MULTILINE)
         if not match:

--- a/pysteel/cloudfoundry.py
+++ b/pysteel/cloudfoundry.py
@@ -212,6 +212,7 @@ class CloudFoundry(object):
             if "App '{}' not found".format(app_name) in str(e):
                 raise CloudFoundryObjectDoesNotExistError()
             if "Requested route" in str(e) and "does not exist" in str(e):
+                self._context.log.error('routing error: {}'.format(e))
                 raise CloudFoundryRouteError()
             raise e
         match = re.search(r'^#0\s+(\S+)', cmd.stdout, re.MULTILINE)

--- a/pysteel/command.py
+++ b/pysteel/command.py
@@ -132,8 +132,6 @@ def resolve_args(context, args, cwd):
     cmd = os.path.split(args[0])[-1]
     if cmd == 'cf':
         resolve_cf_args(context, args, cwd)
-    if cmd == 'uaac':
-        resolve_uaac_args(context, args, cwd)
     return args
 
 
@@ -152,14 +150,3 @@ def resolve_cf_args(context, args, cwd):
             if match:
                 app = match.group(1)
                 # args += ['--hostname', dns.resolve_hostname(context, app)] <-- deprecated in cf cli v7, now requires use of cf map-route command
-
-
-def resolve_uaac_args(context, args, cwd):
-    """
-    :type context: behave.runner.Context
-    :type args: list
-    :type cwd: str
-    """
-    if '--redirect_uri' in args:
-        idx = args.index('--redirect_uri') + 1
-        args[idx] = dns.resolve_url(context, args[idx])

--- a/steps/process_steps.py
+++ b/steps/process_steps.py
@@ -3,7 +3,7 @@ import time
 
 from behave import *
 
-from pysteel.cloudfoundry import CloudFoundry, CloudFoundryObjectDoesNotExistError
+from pysteel.cloudfoundry import CloudFoundry, CloudFoundryObjectDoesNotExistError, CloudFoundryRouteError
 from pysteel.command import Command
 
 
@@ -88,6 +88,8 @@ def step_impl(context, app):
                 assert False, "app {} crashed".format(app)
             return status == 'running'
         except CloudFoundryObjectDoesNotExistError:
+            return False
+        except CloudFoundryRouteError:
             return False
 
     try_until(context, app_started, context.options.cf.max_attempts)


### PR DESCRIPTION
This branch was created off of `main` and also cherry-picked a couple commits from the `refresh-connector-samples` branch.

The fix avoids the use of random routes for the SingleSignon tests since the UAA and SingleSignon app URLs must be known before the respective app is created.