### PR TITLE
Fix broken docker link

### DIFF
--- a/CommonTasks.md
+++ b/CommonTasks.md
@@ -79,7 +79,7 @@ docker run --rm -ti -p 5672:5672 -p 15672:15672 --name rabbitmq rabbitmq:3-manag
 ### Run Consul Server with Docker
 
 ```script
-docker run --rm -ti -p 8500:8500 --name=steeltoe-consul consul
+docker run --rm -ti -p 8500:8500 --name=steeltoe-consul hashicorp/consul
 ```
 
 ## Spring Boot Admin


### PR DESCRIPTION
See https://hub.docker.com/_/consul:
> Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/consul instead of consul. Verified Publisher images can be found at https://hub.docker.com/r/hashicorp/consul.