### PR TITLE
Update auth sample to inject typed HttpClient, improve logging and error display

### DIFF
--- a/Security/src/AuthWeb/ApiClients/CertificateAuthorizationApiClient.cs
+++ b/Security/src/AuthWeb/ApiClients/CertificateAuthorizationApiClient.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Steeltoe.Samples.AuthWeb.Models;
+
+namespace Steeltoe.Samples.AuthWeb.ApiClients;
+
+public sealed class CertificateAuthorizationApiClient(HttpClient httpClient)
+    : StringApiClient(httpClient)
+{
+    public async Task<AuthApiResponseModel> GetSameOrgAsync(CancellationToken cancellationToken)
+    {
+        return await GetAsync("/api/certificate/SameOrg", cancellationToken);
+    }
+
+    public async Task<AuthApiResponseModel> GetSameSpaceAsync(CancellationToken cancellationToken)
+    {
+        return await GetAsync("/api/certificate/SameSpace", cancellationToken);
+    }
+}

--- a/Security/src/AuthWeb/ApiClients/JwtAuthorizationApiClient.cs
+++ b/Security/src/AuthWeb/ApiClients/JwtAuthorizationApiClient.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Steeltoe.Samples.AuthWeb.Models;
+
+namespace Steeltoe.Samples.AuthWeb.ApiClients;
+
+public sealed class JwtAuthorizationApiClient(HttpClient httpClient)
+    : StringApiClient(httpClient)
+{
+    public async Task<AuthApiResponseModel> GetAuthorizationAsync(string? accessToken, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(accessToken))
+        {
+            return new AuthApiResponseModel
+            {
+                Error = new InvalidOperationException(
+                    "No access token found in user session. Perhaps you need to set 'Authentication:Schemes:OpenIdConnect:SaveTokens' to 'true'?")
+            };
+        }
+
+        HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        return await GetAsync("/api/JwtAuthorization", cancellationToken);
+    }
+}

--- a/Security/src/AuthWeb/ApiClients/StringApiClient.cs
+++ b/Security/src/AuthWeb/ApiClients/StringApiClient.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Steeltoe.Samples.AuthWeb.Models;
+
+namespace Steeltoe.Samples.AuthWeb.ApiClients;
+
+public abstract class StringApiClient(HttpClient httpClient)
+{
+    protected HttpClient HttpClient => httpClient;
+
+    protected async Task<AuthApiResponseModel> GetAsync(string requestUri, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using HttpResponseMessage response = await httpClient.GetAsync(requestUri, cancellationToken);
+            string responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return new AuthApiResponseModel
+                {
+                    Message = responseBody
+                };
+            }
+
+            throw new HttpRequestException($"Request failed with status {(int)response.StatusCode}:{Environment.NewLine}{responseBody}");
+        }
+        catch (Exception exception)
+        {
+            return new AuthApiResponseModel
+            {
+                Error = exception
+            };
+        }
+    }
+}

--- a/Security/src/AuthWeb/HttpClientBuilderExtensions.cs
+++ b/Security/src/AuthWeb/HttpClientBuilderExtensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Http.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Steeltoe.Samples.AuthWeb;
+
+/// <summary>
+/// Provides simplified logging of outgoing HTTP requests.
+/// </summary>
+/// <remarks>
+/// Based on https://josef.codes/customize-the-httpclient-logging-dotnet-core/.
+/// </remarks>
+public static class HttpClientBuilderExtensions
+{
+    public static IHttpClientBuilder ConfigureLogging(this IHttpClientBuilder builder)
+    {
+        builder.Services.TryAddScoped<HttpLogger>();
+        return builder.RemoveAllLoggers().AddLogger<HttpLogger>(true);
+    }
+
+    private sealed class HttpLogger(ILogger<HttpLogger> logger) : IHttpClientLogger
+    {
+        private readonly ILogger<HttpLogger> _logger = logger;
+
+        public object? LogRequestStart(HttpRequestMessage request)
+        {
+            _logger.LogInformation("Sending '{Request.Method}' to '{Request.Host}{Request.Path}'", request.Method,
+                request.RequestUri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped), request.RequestUri?.PathAndQuery);
+
+            return null;
+        }
+
+        public void LogRequestStop(object? context, HttpRequestMessage request, HttpResponseMessage response, TimeSpan elapsed)
+        {
+            _logger.LogInformation("Received '{Response.StatusCodeInt} {Response.StatusCodeString}' after {Response.ElapsedMilliseconds}ms",
+                (int)response.StatusCode, response.StatusCode, elapsed.TotalMilliseconds.ToString("F1"));
+        }
+
+        public void LogRequestFailed(object? context, HttpRequestMessage request, HttpResponseMessage? response, Exception exception, TimeSpan elapsed)
+        {
+            _logger.LogError(exception, "Request towards '{Request.Host}{Request.Path}' failed after {Response.ElapsedMilliseconds}ms",
+                request.RequestUri?.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped), request.RequestUri!.PathAndQuery,
+                elapsed.TotalMilliseconds.ToString("F1"));
+        }
+    }
+}

--- a/Security/src/AuthWeb/Models/AuthApiResponseModel.cs
+++ b/Security/src/AuthWeb/Models/AuthApiResponseModel.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Steeltoe.Samples.AuthWeb.Models;
+
+public sealed class AuthApiResponseModel
+{
+    public string? Message { get; set; }
+    public Exception? Error { get; set; }
+}

--- a/Security/src/AuthWeb/Program.cs
+++ b/Security/src/AuthWeb/Program.cs
@@ -14,6 +14,7 @@ using Steeltoe.Configuration.CloudFoundry;
 using Steeltoe.Configuration.CloudFoundry.ServiceBindings;
 using Steeltoe.Management.Endpoint.Actuators.All;
 using Steeltoe.Samples.AuthWeb;
+using Steeltoe.Samples.AuthWeb.ApiClients;
 using Steeltoe.Security.Authentication.OpenIdConnect;
 using Steeltoe.Security.Authorization.Certificate;
 
@@ -48,8 +49,8 @@ builder.Services.AddAuthorizationBuilder().AddPolicy(Globals.RequiredJwtScope, p
     .AddPolicy(Globals.UnknownJwtScope, policy => policy.RequireClaim("scope", Globals.UnknownJwtScope));
 
 // Steeltoe: Register HttpClients for communicating with a backend service, including an application instance certificate for authorization.
-builder.Services.AddHttpClient("default", SetBaseAddress);
-builder.Services.AddHttpClient("AppInstanceIdentity", SetBaseAddress).AddAppInstanceIdentityCertificate();
+builder.Services.AddHttpClient<JwtAuthorizationApiClient>(SetBaseAddress).ConfigureLogging();
+builder.Services.AddHttpClient<CertificateAuthorizationApiClient>(SetBaseAddress).AddAppInstanceIdentityCertificate().ConfigureLogging();
 
 // Steeltoe: Add actuator endpoints.
 builder.Services.AddAllActuators();

--- a/Security/src/AuthWeb/Views/Home/InvokeService.cshtml
+++ b/Security/src/AuthWeb/Views/Home/InvokeService.cshtml
@@ -1,6 +1,21 @@
-﻿@model string
+﻿@model Steeltoe.Samples.AuthWeb.Models.AuthApiResponseModel
 @{
     ViewData["Title"] = "Invoke a backend service";
 }
+
 <h2>@ViewData["Title"].</h2>
-<h3>@Model</h3>
+
+@if (Model.Error != null)
+{
+    <div class="alert alert-danger" role="alert">
+        <h2>Error</h2>
+        <pre>@Model.Error.ToString()</pre>
+    </div>
+}
+else
+{
+    <div class="alert alert-success" role="alert">
+        <h2>Success</h2>
+        @Model.Message
+    </div>
+}


### PR DESCRIPTION
Fixes #345.

Example log output:
```
info: Steeltoe.Samples.AuthWeb.HttpClientBuilderExtensions.HttpLogger[0]
      Sending 'GET' to 'https://localhost:7184/api/JwtAuthorization'
info: Steeltoe.Samples.AuthWeb.HttpClientBuilderExtensions.HttpLogger[0]
      Received '401 Unauthorized' after 8531,6ms
info: Steeltoe.Samples.AuthWeb.HttpClientBuilderExtensions.HttpLogger[0]
      Sending 'GET' to 'https://localhost:7184/api/certificate/SameOrg'
info: Steeltoe.Samples.AuthWeb.HttpClientBuilderExtensions.HttpLogger[0]
      Received '200 OK' after 48,1ms
```

Example error display:

![image](https://github.com/user-attachments/assets/c38bcfac-614a-4af5-8a19-e7f2890549ef)
