### PR TITLE
Add Valkey to Redis samples, update broken links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,2 @@
 If you have not previously done so, please fill out and
-submit the [Contributor License Agreement](https://cla.pivotal.io/sign/pivotal).
+submit the [Contributor License Agreement](https://cla.dotnetfoundation.org/).

--- a/CommonTasks.md
+++ b/CommonTasks.md
@@ -160,7 +160,7 @@ docker run --rm -it --pull=always -p 8080:8080 --name steeltoe-uaa steeltoe.azur
 
 ### Run Steeltoe UAA on Cloud Foundry
 
-Refer to the [README in the Dockerfiles repository](https://github.com/SteeltoeOSS/Dockerfiles/tree/main/uaa-server/README.md) for instructions.
+Refer to the [README in the Dockerfiles repository](https://github.com/SteeltoeOSS/Dockerfiles/blob/main/uaa-server/README.md) for instructions.
 
 ## Zipkin
 

--- a/CommonTasks.md
+++ b/CommonTasks.md
@@ -132,6 +132,14 @@ docker run --rm -it --pull=always -p 5672:5672 -p 15672:15672 --name rabbitmq ra
 docker run --rm -it --pull=always -p 6379:6379 --name redis redis
 ```
 
+## Valkey
+
+### Run Valkey server with Docker
+
+```shell
+docker run --rm -it --pull=always -p 6379:6379 --name valkey valkey/valkey
+```
+
 ## SQL Server
 
 ### Run SQL Server with Docker

--- a/CommonTasks.md
+++ b/CommonTasks.md
@@ -49,7 +49,7 @@ The default configuration of the Config Server uses [this github repo](https://g
 
 ### Provision SCCS on Cloud Foundry
 
-Use the [cf cli](https://github.com/cloudfoundry/cli) to create a Spring Cloud Config Server in a org/space, backed by a given git repo. Many of the Steeltoe samples use the `spring-cloud-samples` repo, but you may need to alter the parameter used.
+Use the [Cloud Foundry CLI](https://github.com/cloudfoundry/cli) to create a Spring Cloud Config Server in an org/space, backed by a given git repo. Many of the Steeltoe samples use the `spring-cloud-samples` repo, but you may need to alter the parameter used.
 
 1. `cf target -o myorg -s myspace`
 1. Use the correct escaping for your shell:

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -1,16 +1,16 @@
-﻿# Steeltoe Configuration Providers Sample App
+# Steeltoe Configuration Providers Sample App
 
 This is an ASP.NET Core application that shows how to use various `IConfiguration` providers that are part of the Steeltoe project.
 
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [Spring Cloud Services for VMware Tanzu](https://docs.vmware.com/en/Spring-Cloud-Services-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
-   with [Application Configuration Service](https://docs.vmware.com/en/Application-Configuration-Service-for-VMware-Tanzu/index.html)
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Spring Cloud Services for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/spring/spring-cloud-services-for-cloud-foundry/3-3/scs-tanzu/index.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
+   with [Application Configuration Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/overview.html)
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally
@@ -55,7 +55,7 @@ kubectl config set-context --current --namespace=your-namespace
 kubectl apply -f ./config/application-configuration-service
 ```
 
-For complete instructions, follow the [documentation](https://docs.vmware.com/en/Application-Configuration-Service-for-VMware-Tanzu/index.html).
+For complete instructions, follow the [documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/overview.html).
 
 ### App deployment
 

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -74,4 +74,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Configuration Documentation](https://docs.steeltoe.io/api/v3/configuration/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Configuration Documentation](https://docs.steeltoe.io/api/v4/configuration/) for more detailed information.

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -8,7 +8,7 @@ This is an ASP.NET Core application that shows how to use various `IConfiguratio
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Spring Cloud Services for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/spring/spring-cloud-services-for-cloud-foundry/3-3/scs-tanzu/index.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    with [Application Configuration Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/overview.html)
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -11,7 +11,7 @@ This is an ASP.NET Core application that shows how to use various `IConfiguratio
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    with [Application Configuration Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/overview.html)
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -70,7 +70,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -70,7 +70,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/README.md
+++ b/Connectors/README.md
@@ -6,13 +6,13 @@ Steeltoe Connectors simplify the coding process of binding to and accessing Clou
 ## ASP.NET Core Samples
 
 * src/CosmosDb - Connect to an Azure CosmosDB database on Cloud Foundry.
-* src/MongoDb - Connect to a MongoDB database on Cloud Foundry.
-* src/MySql - Connect to a MySQL database on Cloud Foundry.
-* src/MySqlEFCore - Connect to a MySQL database through an Entity Framework Core `DbContext` on Cloud Foundry.
+* src/MongoDb - Connect to a MongoDB database on Cloud Foundry or Kubernetes.
+* src/MySql - Connect to a MySQL database on Cloud Foundry or Kubernetes.
+* src/MySqlEFCore - Connect to a MySQL database through an Entity Framework Core `DbContext` on Cloud Foundry or Kubernetes.
 * src/PostgreSql - Connect to a PostgreSQL database on Cloud Foundry or Kubernetes.
 * src/PostgreSqlEFCore - Connect to a PostgreSQL database through an Entity Framework Core `DbContext` on Cloud Foundry or Kubernetes.
-* src/RabbitMQ - Connect to a RabbitMQ server on Cloud Foundry.
-* src/Redis - Connect a [Microsoft Redis Cache Extension](https://github.com/aspnet/Caching/tree/dev/src/Microsoft.Extensions.Caching.Redis) and/or a [ConnectionMultiplexor](https://github.com/StackExchange/StackExchange.Redis) to a Redis cache on Cloud Foundry.
+* src/RabbitMQ - Connect to a RabbitMQ server on Cloud Foundry or Kubernetes.
+* src/Redis - Connect to a Redis cache on Cloud Foundry or Kubernetes and configure [IDistributedCache](https://www.nuget.org/packages/Microsoft.Extensions.Caching.Redis).
 * src/SqlServerEFCore - Connect to a Microsoft SQL Server database through an Entity Framework Core `DbContext` on Cloud Foundry.
 
 ## Building & Running

--- a/Connectors/README.md
+++ b/Connectors/README.md
@@ -21,4 +21,4 @@ See the Readme for instructions on building and running each app.
 
 ---
 
-See the Official [Steeltoe Service Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/CosmosDb/README.md
+++ b/Connectors/src/CosmosDb/README.md
@@ -13,7 +13,7 @@ for connecting to a CosmosDB database.
 
 ## Running locally
 
-1. Start the [Azure CosmosDB Emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator)
+1. Start the [Azure CosmosDB Emulator](https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator)
 1. Update your local primary key in `appsettings.development.json` at `Steeltoe:Client:CosmosDb:Default:ConnectionString`
 1. Run the sample
    ```

--- a/Connectors/src/CosmosDb/README.md
+++ b/Connectors/src/CosmosDb/README.md
@@ -9,7 +9,7 @@ for connecting to a CosmosDB database.
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-10/csb-azure/reference-azure-cosmosdb-sql.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 
 ## Running locally
 

--- a/Connectors/src/CosmosDb/README.md
+++ b/Connectors/src/CosmosDb/README.md
@@ -1,6 +1,6 @@
 # CosmosDB Connector Sample App
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe CosmosDB Connector](https://docs.steeltoe.io/api/v3/connectors/cosmosdb.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe CosmosDB Connector](https://docs.steeltoe.io/api/v4/connectors/cosmosdb.html)
 for connecting to a CosmosDB database.
 
 ## General pre-requisites
@@ -40,4 +40,4 @@ Upon startup, the app inserts a couple of objects into the bound CosmosDB databa
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/CosmosDb/README.md
+++ b/Connectors/src/CosmosDb/README.md
@@ -1,4 +1,4 @@
-﻿# CosmosDB Connector Sample App
+# CosmosDB Connector Sample App
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe CosmosDB Connector](https://docs.steeltoe.io/api/v3/connectors/cosmosdb.html)
 for connecting to a CosmosDB database.
@@ -6,10 +6,10 @@ for connecting to a CosmosDB database.
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-10/csb-azure/reference-azure-cosmosdb-sql.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
 
 ## Running locally
 

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -9,7 +9,7 @@ for connecting to a MongoDB database.
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-cosmosdb-mongo.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.6 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -1,4 +1,4 @@
-﻿# MongoDB Connector Sample App
+# MongoDB Connector Sample App
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe MongoDB Connector](https://docs.steeltoe.io/api/v3/connectors/mongodb.html)
 for connecting to a MongoDB database.
@@ -6,11 +6,11 @@ for connecting to a MongoDB database.
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.6 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-cosmosdb-mongo.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.6 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -1,6 +1,6 @@
 # MongoDB Connector Sample App
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe MongoDB Connector](https://docs.steeltoe.io/api/v3/connectors/mongodb.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe MongoDB Connector](https://docs.steeltoe.io/api/v4/connectors/mongodb.html)
 for connecting to a MongoDB database.
 
 ## General pre-requisites
@@ -72,4 +72,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -52,8 +52,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -68,7 +68,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -11,7 +11,7 @@ for connecting to a MongoDB database.
    with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-cosmosdb-mongo.html)
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.6 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -68,7 +68,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -70,8 +70,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -86,7 +86,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -1,4 +1,4 @@
-﻿# MySQL Connector Sample App - MySqlConnection
+# MySQL Connector Sample App - MySqlConnection
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v3/connectors/mysql.html)
 for connecting to a MySQL database.
@@ -8,12 +8,16 @@ There is also an additional sample that illustrates how to use Entity Framework 
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware MySQL for Tanzu Application Service](https://docs.vmware.com/en/VMware-SQL-with-MySQL-for-Tanzu-Application-Service/index.html)
-   or [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Tanzu for MySQL on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-for-mysql-on-cloud-foundry/3-3/mysql-for-tpcf/about_mysql_vms.html)
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-mysql.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-mysql.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally
@@ -32,15 +36,15 @@ Upon startup, the app inserts a couple of rows into the bound MySQL database. Th
    ```
    cf target -o your-org -s your-space
    ```
-   - When using VMware MySQL for Tanzu Application Service:
+   - When using Tanzu for MySQL on Cloud Foundry:
      ```
      cf create-service p.mysql db-small sampleMySqlService
      ```
-   - When using the Cloud Service Broker for Azure:
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
      ```
      cf create-service csb-azure-mysql small sampleMySqlService
      ```
-   - When using the Cloud Service Broker for GCP:
+   - When using Tanzu Cloud Service Broker for GCP:
      ```
      cf create-service csb-google-mysql your-plan sampleMySqlService
      ```

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -86,7 +86,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -16,7 +16,7 @@ There is also an additional sample that illustrates how to use Entity Framework 
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-mysql.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-mysql.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -18,7 +18,7 @@ There is also an additional sample that illustrates how to use Entity Framework 
 
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -1,6 +1,6 @@
 # MySQL Connector Sample App - MySqlConnection
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v3/connectors/mysql.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v4/connectors/mysql.html)
 for connecting to a MySQL database.
 This sample illustrates using a `MySqlConnection` to issue commands to the bound database.
 There is also an additional sample that illustrates how to use Entity Framework Core.
@@ -90,4 +90,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -1,6 +1,6 @@
 # MySQL Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v3/connectors/mysql.html#entity-framework-core)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v4/connectors/mysql.html#entity-framework-core)
 for connecting to a MySQL database.
 There is also an additional sample that illustrates how to use a `MySqlConnection` to issue commands to the bound database.
 
@@ -89,4 +89,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -69,8 +69,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -85,7 +85,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -85,7 +85,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -17,7 +17,7 @@ There is also an additional sample that illustrates how to use a `MySqlConnectio
 
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -1,6 +1,6 @@
 # MySQL Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v4/connectors/mysql.html#entity-framework-core)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v4/connectors/mysql.html#use-entity-framework-core)
 for connecting to a MySQL database.
 There is also an additional sample that illustrates how to use a `MySqlConnection` to issue commands to the bound database.
 

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -15,7 +15,7 @@ There is also an additional sample that illustrates how to use a `MySqlConnectio
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-mysql.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-mysql.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -1,4 +1,4 @@
-﻿# MySQL Connector Sample App - Entity Framework Core
+# MySQL Connector Sample App - Entity Framework Core
 
 ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe MySQL Connector](https://docs.steeltoe.io/api/v3/connectors/mysql.html#entity-framework-core)
 for connecting to a MySQL database.
@@ -7,12 +7,16 @@ There is also an additional sample that illustrates how to use a `MySqlConnectio
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware MySQL for Tanzu Application Service](https://docs.vmware.com/en/VMware-SQL-with-MySQL-for-Tanzu-Application-Service/index.html)
-   or [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Tanzu for MySQL on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-for-mysql-on-cloud-foundry/3-3/mysql-for-tpcf/about_mysql_vms.html)
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-mysql.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-mysql.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally
@@ -31,15 +35,15 @@ Upon startup, the app inserts a couple of rows into the bound MySQL database. Th
    ```
    cf target -o your-org -s your-space
    ```
-   - When using VMware MySQL for Tanzu Application Service:
+   - When using Tanzu for MySQL on Cloud Foundry:
      ```
      cf create-service p.mysql db-small sampleMySqlService
      ```
-   - When using the Cloud Service Broker for Azure:
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
      ```
      cf create-service csb-azure-mysql small sampleMySqlService
      ```
-   - When using the Cloud Service Broker for GCP:
+   - When using Tanzu Cloud Service Broker for GCP:
      ```
      cf create-service csb-google-mysql your-plan sampleMySqlService
      ```

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -81,7 +81,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Connector Sample App - NpgsqlConnection
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v3/connectors/postgresql.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v4/connectors/postgresql.html)
 for connecting to a PostgreSQL database.
 This sample illustrates using a `NpgsqlConnection` to issue commands to the bound database.
 There is also an additional sample that illustrates how to use Entity Framework Core.
@@ -85,4 +85,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -15,7 +15,7 @@ There is also an additional sample that illustrates how to use Entity Framework 
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-postgresql.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-postgresql.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -65,8 +65,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -81,7 +81,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -1,4 +1,4 @@
-﻿# PostgreSQL Connector Sample App - NpgsqlConnection
+# PostgreSQL Connector Sample App - NpgsqlConnection
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v3/connectors/postgresql.html)
 for connecting to a PostgreSQL database.
@@ -8,11 +8,15 @@ There is also an additional sample that illustrates how to use Entity Framework 
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-postgresql.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-postgresql.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally
@@ -31,11 +35,11 @@ Upon startup, the app inserts a couple of rows into the bound PostgreSQL databas
    ```
    cf target -o your-org -s your-space
    ```
-   - When using the Cloud Service Broker for Azure:
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
      ```
      cf create-service csb-azure-postgresql mini samplePostgreSqlService
      ```
-   - When using the Cloud Service Broker for GCP:
+   - When using Tanzu Cloud Service Broker for GCP:
      ```
      cf create-service csb-google-postgres gcp-postgres-tiny samplePostgreSqlService
      ```

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -17,7 +17,7 @@ There is also an additional sample that illustrates how to use Entity Framework 
 
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v4/connectors/postgresql.html#add-dbcontext)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v4/connectors/postgresql.html#use-entity-framework-core)
 for connecting to a PostgreSQL database.
 There is also an additional sample that illustrates how to use a `NpgsqlConnection` to issue commands to the bound database.
 

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -80,7 +80,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -1,4 +1,4 @@
-﻿# PostgreSQL Connector Sample App - Entity Framework Core
+# PostgreSQL Connector Sample App - Entity Framework Core
 
 ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v3/connectors/postgresql.html#add-dbcontext)
 for connecting to a PostgreSQL database.
@@ -7,11 +7,15 @@ There is also an additional sample that illustrates how to use a `NpgsqlConnecti
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-postgresql.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-postgresql.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally
@@ -30,11 +34,11 @@ Upon startup, the app inserts a couple of rows into the bound PostgreSQL databas
    ```
    cf target -o your-org -s your-space
    ```
-   - When using the Cloud Service Broker for Azure:
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
      ```
      cf create-service csb-azure-postgresql mini samplePostgreSqlService
      ```
-   - When using the Cloud Service Broker for GCP:
+   - When using Tanzu Cloud Service Broker for GCP:
      ```
      cf create-service csb-google-postgres gcp-postgres-tiny samplePostgreSqlService
      ```

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v3/connectors/postgresql.html#add-dbcontext)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe PostgreSQL Connector](https://docs.steeltoe.io/api/v4/connectors/postgresql.html#add-dbcontext)
 for connecting to a PostgreSQL database.
 There is also an additional sample that illustrates how to use a `NpgsqlConnection` to issue commands to the bound database.
 
@@ -84,4 +84,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -16,7 +16,7 @@ There is also an additional sample that illustrates how to use a `NpgsqlConnecti
 
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -14,7 +14,7 @@ There is also an additional sample that illustrates how to use a `NpgsqlConnecti
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-9/csb-azure/reference-azure-postgresql.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-8/csb-gcp/reference-gcp-postgresql.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -64,8 +64,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -80,7 +80,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -1,4 +1,4 @@
-﻿# RabbitMQ Connector Sample App - RabbitMQConnection
+# RabbitMQ Connector Sample App - RabbitMQConnection
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe RabbitMQ Connector](https://docs.steeltoe.io/api/v3/connectors/rabbitmq.html)
 for connecting to a RabbitMQ server.
@@ -7,11 +7,11 @@ This sample illustrates using an `IConnection` to send and receive messages on t
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu RabbitMQ for Tanzu Application Service](https://docs.vmware.com/en/VMware-Tanzu-RabbitMQ-for-Tanzu-Application-Service/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Tanzu RabbitMQ on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-on-cloud-foundry/10-0/tanzu-rabbitmq-cloud-foundry/index.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 
 ## Running locally

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -10,7 +10,7 @@ This sample illustrates using an `IConnection` to send and receive messages on t
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Tanzu RabbitMQ on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-on-cloud-foundry/10-0/tanzu-rabbitmq-cloud-foundry/index.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ Connector Sample App - RabbitMQConnection
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe RabbitMQ Connector](https://docs.steeltoe.io/api/v3/connectors/rabbitmq.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe RabbitMQ Connector](https://docs.steeltoe.io/api/v4/connectors/rabbitmq.html)
 for connecting to a RabbitMQ server.
 This sample illustrates using an `IConnection` to send and receive messages on the bound RabbitMQ service.
 
@@ -74,4 +74,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -12,7 +12,7 @@ This sample illustrates using an `IConnection` to send and receive messages on t
    with [Tanzu RabbitMQ on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-rabbitmq-on-cloud-foundry/10-0/tanzu-rabbitmq-cloud-foundry/index.html)
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 ## Running locally
 

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -70,7 +70,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -54,8 +54,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -70,7 +70,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -94,7 +94,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.8/tap/getting-started-deploy-first-app.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
 
 ---
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -19,7 +19,7 @@ This sample uses [StackExchange.Redis](https://www.nuget.org/packages/StackExcha
 
    and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
-   and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+   and [Tanzu CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/install-tanzu-cli.html)
 
 > [!NOTE]
 > Versions of ASP.NET before v9 require that Lua scripting is activated, which is disabled by default on Cloud Foundry, so check your plan settings.

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -1,7 +1,7 @@
-﻿# Redis Connector Sample App
+# Redis Connector Sample App
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe Redis Connector](https://docs.steeltoe.io/api/v3/connectors/redis.html)
-to connect to a Redis server.
+to connect to a Redis or Valkey server.
 This sample uses both [Microsoft RedisCache](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.redis.rediscache)
 and [StackExchange `ConnectionMultiplexer`](https://github.com/StackExchange/StackExchange.Redis) to work with the same Redis service.
 
@@ -20,13 +20,13 @@ and [StackExchange `ConnectionMultiplexer`](https://github.com/StackExchange/Sta
 
 ## Running locally
 
-1. Start a Redis [docker container](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md)
+1. Start a Redis or Valkey [docker container](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md)
 1. Run the sample
    ```
    dotnet run
    ```
 
-Upon startup, the app inserts a couple of key/value pairs into the bound Redis cache using both APIs. They are displayed on the home page.
+Upon startup, the app inserts a couple of key/value pairs into the bound Redis/Valkey cache using both APIs. They are displayed on the home page.
 
 ## Running on Tanzu Platform for Cloud Foundry
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -17,7 +17,7 @@ This sample uses [StackExchange.Redis](https://www.nuget.org/packages/StackExcha
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-redis.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-5/csb-gcp/reference-gcp-redis.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -8,15 +8,21 @@ and [StackExchange `ConnectionMultiplexer`](https://github.com/StackExchange/Sta
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [Redis for VMware Tanzu Application Service](https://docs.vmware.com/en/Redis-for-VMware-Tanzu-Application-Service/index.html)
-   or [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
-   > [!NOTE]
-   > ASP.NET before v9 requires that Lua scripting is activated, which is disabled by default on Cloud Foundry (check your plan settings)
-1. Optional: [VMware Tanzu Platform for Kubernetes](https://docs.vmware.com/en/VMware-Tanzu-Platform/services/create-manage-apps-tanzu-platform-k8s/overview.html) v1.5 or higher
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Redis for Tanzu Application Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/redis-for-tanzu-application-service/3-5/redis-for-tas/index.html)
+   - [Tanzu for Valkey on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-for-valkey-on-cloud-foundry/4-0/valkey-on-cf/index.html)
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-redis.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-5/csb-gcp/reference-gcp-redis.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+1. Optional: [Tanzu Platform for Kubernetes](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/overview.html) v1.5 or higher
    and [Kubernetes](https://kubernetes.io/docs/tasks/tools/)
+
+> [!NOTE]
+> Versions of ASP.NET before v9 require that Lua scripting is activated, which is disabled by default on Cloud Foundry, so check your plan settings.
 
 ## Running locally
 
@@ -34,7 +40,7 @@ Upon startup, the app inserts a couple of key/value pairs into the bound Redis/V
    ```
    cf target -o your-org -s your-space
    ```
-   - When using Redis for VMware Tanzu Application Service:
+   - When using Redis for Tanzu Application Service or Tanzu for Valkey on Cloud Foundry:
      ```
      cf create-service p.redis on-demand-cache sampleRedisService
      ```
@@ -42,11 +48,11 @@ Upon startup, the app inserts a couple of key/value pairs into the bound Redis/V
      ```
      cf create-service p-redis shared-vm sampleRedisService
      ```
-   - When using the Cloud Service Broker for Azure:
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
      ```
      cf create-service csb-azure-redis your-plan sampleRedisService
      ```
-   - When using the Cloud Service Broker for GCP:
+   - When using Tanzu Cloud Service Broker for GCP:
      ```
      cf create-service csb-google-redis your-plan sampleRedisService
      ```

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -78,8 +78,8 @@ kubectl config set-context --current --namespace=your-namespace
 tanzu service class-claim create my-postgresql-service --class postgresql-unmanaged
 ```
 
-If you'd like to learn more about these services, see [claiming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html)
-and [consuming services](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html) in the documentation.
+If you'd like to learn more about these services, see [claiming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-claim-services.html)
+and [consuming services](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-consume-services.html) in the documentation.
 
 ### App deployment
 
@@ -94,7 +94,7 @@ dotnet publish -r linux-x64 --no-self-contained
 tanzu app workload apply --local-path ./bin/Release/net8.0/linux-x64/publish --file ./config/workload.yaml -y
 ```
 
-See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/application-configuration-service-for-tanzu/2-4/app-config-service/gettingstarted-index.html) for details.
+See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/standalone-components/tanzu-application-platform/1-12/tap/getting-started-deploy-first-app.html) for details.
 
 ---
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -2,8 +2,8 @@
 
 ASP.NET Core sample app illustrating how to use the [Steeltoe Redis Connector](https://docs.steeltoe.io/api/v4/connectors/redis.html)
 to connect to a Redis or Valkey server.
-This sample uses both [Microsoft RedisCache](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.redis.rediscache)
-and [StackExchange `ConnectionMultiplexer`](https://github.com/StackExchange/StackExchange.Redis) to work with the same Redis service.
+This sample uses [StackExchange.Redis](https://www.nuget.org/packages/StackExchange.Redis) and
+[Microsoft.Extensions.Caching.Redis](https://www.nuget.org/packages/StackExchange.Redis) to work with the same Redis service.
 
 ## General pre-requisites
 

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -1,6 +1,6 @@
 # Redis Connector Sample App
 
-ASP.NET Core sample app illustrating how to use the [Steeltoe Redis Connector](https://docs.steeltoe.io/api/v3/connectors/redis.html)
+ASP.NET Core sample app illustrating how to use the [Steeltoe Redis Connector](https://docs.steeltoe.io/api/v4/connectors/redis.html)
 to connect to a Redis or Valkey server.
 This sample uses both [Microsoft RedisCache](https://learn.microsoft.com/dotnet/api/microsoft.extensions.caching.redis.rediscache)
 and [StackExchange `ConnectionMultiplexer`](https://github.com/StackExchange/StackExchange.Redis) to work with the same Redis service.
@@ -98,4 +98,4 @@ See the [Tanzu documentation](https://techdocs.broadcom.com/us/en/vmware-tanzu/s
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/SqlServerEFCore/README.md
+++ b/Connectors/src/SqlServerEFCore/README.md
@@ -1,6 +1,6 @@
 # SQL Server Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe SQL Server Connector](https://docs.steeltoe.io/api/v3/connectors/microsoft-sql-server.html)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe SQL Server Connector](https://docs.steeltoe.io/api/v4/connectors/microsoft-sql-server.html)
 for connecting to a Microsoft SQL Server database.
 
 ## General pre-requisites
@@ -40,4 +40,4 @@ Upon startup, the app inserts a couple of rows into the bound SQL Server databas
 
 ---
 
-See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v3/connectors/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Connectors Documentation](https://docs.steeltoe.io/api/v4/connectors/) for more detailed information.

--- a/Connectors/src/SqlServerEFCore/README.md
+++ b/Connectors/src/SqlServerEFCore/README.md
@@ -1,6 +1,6 @@
 # SQL Server Connector Sample App - Entity Framework Core
 
-ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe SQL Server Connector](https://docs.steeltoe.io/api/v4/connectors/microsoft-sql-server.html)
+ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe SQL Server Connector](https://docs.steeltoe.io/api/v4/connectors/microsoft-sql-server.html#use-entity-framework-core)
 for connecting to a Microsoft SQL Server database.
 
 ## General pre-requisites

--- a/Connectors/src/SqlServerEFCore/README.md
+++ b/Connectors/src/SqlServerEFCore/README.md
@@ -1,4 +1,4 @@
-﻿# SQL Server Connector Sample App - Entity Framework Core
+# SQL Server Connector Sample App - Entity Framework Core
 
 ASP.NET Core sample app illustrating how to use Entity Framework Core together with the [Steeltoe SQL Server Connector](https://docs.steeltoe.io/api/v3/connectors/microsoft-sql-server.html)
 for connecting to a Microsoft SQL Server database.
@@ -6,10 +6,10 @@ for connecting to a Microsoft SQL Server database.
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [VMware Tanzu Cloud Service Broker](https://docs.vmware.com/en/Cloud-Service-Broker-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-mssql-db.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
 
 ## Running locally
 

--- a/Connectors/src/SqlServerEFCore/README.md
+++ b/Connectors/src/SqlServerEFCore/README.md
@@ -9,7 +9,7 @@ for connecting to a Microsoft SQL Server database.
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-mssql-db.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 
 ## Running locally
 

--- a/Discovery/README.md
+++ b/Discovery/README.md
@@ -10,4 +10,4 @@ See the readme for instructions on building and running each app.
 
 ---
 
-See the Official [Steeltoe Service Discovery Documentation](https://docs.steeltoe.io/api/v3/discovery) and [Steeltoe Getting Started with Discovery Guide](https://docs.steeltoe.io/guides/service-discovery/eureka.html) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Service Discovery Documentation](https://docs.steeltoe.io/api/v4/discovery) for more detailed information.

--- a/Discovery/src/FortuneTeller/README.md
+++ b/Discovery/src/FortuneTeller/README.md
@@ -223,4 +223,4 @@ with Eureka at startup. FortuneTellerApi is configured to obtain the URL to Conf
 
 ---
 
-See the Official [Steeltoe Service Discovery Documentation](https://docs.steeltoe.io/api/v3/discovery) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Service Discovery Documentation](https://docs.steeltoe.io/api/v4/discovery) for more detailed information.

--- a/Discovery/src/FortuneTeller/README.md
+++ b/Discovery/src/FortuneTeller/README.md
@@ -15,7 +15,7 @@ switching to `http` or `https` and replacing `fortuneService` with the real host
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Spring Cloud Services for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/spring/spring-cloud-services-for-cloud-foundry/3-3/scs-tanzu/index.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 
 ## Configuration-based discovery
 

--- a/Discovery/src/FortuneTeller/README.md
+++ b/Discovery/src/FortuneTeller/README.md
@@ -1,4 +1,4 @@
-﻿# FortuneTeller Discovery Sample Application
+# FortuneTeller Discovery Sample Application
 
 This sample demonstrates Steeltoe Service Discovery. It consists of the following projects:
 
@@ -12,10 +12,10 @@ switching to `http` or `https` and replacing `fortuneService` with the real host
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [Spring Cloud Services for VMware Tanzu](https://docs.vmware.com/en/Spring-Cloud-Services-for-VMware-Tanzu/index.html)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Spring Cloud Services for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/spring/spring-cloud-services-for-cloud-foundry/3-3/scs-tanzu/index.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
 
 ## Configuration-based discovery
 

--- a/Management/src/ActuatorApi/README.md
+++ b/Management/src/ActuatorApi/README.md
@@ -1,4 +1,4 @@
-﻿# Steeltoe Management Sample - Actuators, Administrative Tasks, Metrics and Tracing
+# Steeltoe Management Sample - Actuators, Administrative Tasks, Metrics and Tracing
 
 ActuatorWeb and ActuatorApi form an ASP.NET Core-powered sample application that demonstrates how to use several Steeltoe libraries on their own and with additional tools.
 
@@ -14,7 +14,7 @@ This application depends on a MySQL database. Refer to [Common Tasks](../../../C
 
 ### Administrative Tasks (initialize the database)
 
-In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api/v3/management/tasks.html), the database schema and its contents are managed as administrative tasks.
+In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api/v4/management/tasks.html), the database schema and its contents are managed as administrative tasks.
 
 1. Apply Entity Framework Core database schema migration scripts:
 
@@ -108,4 +108,4 @@ Depending on the steps taken to push the application to Cloud Foundry, the comma
 
 ---
 
-See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v3/management/) for more information.
+See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v4/management/) for more detailed information.

--- a/Management/src/ActuatorWeb/Program.cs
+++ b/Management/src/ActuatorWeb/Program.cs
@@ -85,7 +85,7 @@ app.MapRazorPages();
 app.Run();
 
 // This code is used to limit complexity in the sample. A real application should use Service Discovery.
-// To learn more about service discovery, review the documentation: https://docs.steeltoe.io/api/v3/discovery/
+// To learn more about service discovery, review the documentation at: https://docs.steeltoe.io/api/v4/discovery/
 static void SetBaseAddress(IServiceProvider serviceProvider, HttpClient client)
 {
     var instanceInfo = serviceProvider.GetRequiredService<IApplicationInstanceInfo>();

--- a/Management/src/ActuatorWeb/README.md
+++ b/Management/src/ActuatorWeb/README.md
@@ -202,4 +202,4 @@ If you wish to collect and view application metrics, the [Metrics Registrar](htt
 
 ---
 
-See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v3/management/) for more information.
+See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v4/management/) for more detailed information.

--- a/Management/src/ActuatorWeb/README.md
+++ b/Management/src/ActuatorWeb/README.md
@@ -16,7 +16,7 @@ Several tools exist that can do this, including [App Metrics for VMware Tanzu](h
 1. Installed .NET 8 SDK
 1. Optional:
     * [VMware Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
-    * [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+    * [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
     * [Metrics Registrar for VMware Tanzu Application Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/metric-registrar-index.html)
     * [App Metrics for VMware Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/app-metrics-for-tanzu/2-2/app-metrics/index.html)
     * [VMware MySQL for Tanzu Application Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-for-mysql-on-cloud-foundry/3-3/mysql-for-tpcf/about_mysql_vms.html)

--- a/Management/src/README.md
+++ b/Management/src/README.md
@@ -2,7 +2,7 @@
 
 This repo tree contains sample apps illustrating how to use the Steeltoe Management Endpoints and Management Tasks for managing and monitoring ASP.NET Core applications.
 Steeltoe Management Endpoints can be used to expose services for checking health, adjusting logging, etc. of your applications.
-The endpoints also seamlessly integrate with [Tanzu Apps Manager](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/console-index.html), providing more information on how your application is behaving.
+The endpoints also seamlessly integrate with [Tanzu Apps Manager](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/console-index.html), providing more information on how your application is behaving.
 
 ## ASP.NET Core Samples
 

--- a/Management/src/README.md
+++ b/Management/src/README.md
@@ -15,4 +15,4 @@ See the Readme for instructions on building and running each app.
 
 ---
 
-See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v3/management/) for more information.
+See the Official [Steeltoe Management Documentation](https://docs.steeltoe.io/api/v4/management/) for more detailed information.

--- a/Security/README.md
+++ b/Security/README.md
@@ -4,7 +4,7 @@ This section of the Samples repository contains applications that use the [Steel
 
 ## ASP.NET Core Samples
 
-* [AuthWeb](src/AuthWeb/README.md) and [AuthApi](src/AuthApi/README.md) - authenticate and authorize with OpenID Connect and JWT Bearer tokens using [Single Sign-On for VMware Tanzu Application Service](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service)) and client certificates.
+* [AuthWeb](src/AuthWeb/README.md) and [AuthApi](src/AuthApi/README.md) - authenticate and authorize with OpenID Connect and JWT Bearer tokens using [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and client certificates.
 * [RedisDataProtection](src/RedisDataProtection/README.md) - use Redis provisioned on Cloud Foundry as a DataProtection Key Store.  Sample illustrates sharing encrypted data stored in an ASP.NET session across multiple instances of an application.
 
 ---

--- a/Security/README.md
+++ b/Security/README.md
@@ -1,6 +1,6 @@
 # Steeltoe Security Sample Applications
 
-This section of the Samples repository contains applications that use the [Steeltoe Security Packages](https://docs.steeltoe.io/api/v3/security/) for authentication, authorization, and data protection.
+This section of the Samples repository contains applications that use the [Steeltoe Security Packages](https://docs.steeltoe.io/api/v4/security/) for authentication, authorization, and data protection.
 
 ## ASP.NET Core Samples
 
@@ -9,4 +9,4 @@ This section of the Samples repository contains applications that use the [Steel
 
 ---
 
-See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v3/security/) for more detailed information
+See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v4/security/) for more detailed information.

--- a/Security/src/AuthApi/README.md
+++ b/Security/src/AuthApi/README.md
@@ -1,6 +1,6 @@
 ﻿# Steeltoe Application Security Server-side Authentication and Authorization
 
-This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with JWT Bearer tokens against [Single Sign-On for VMware Tanzu Application Service](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
+This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with JWT Bearer tokens against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
 
 This sample illustrates how you can secure your web api endpoints using JWT Bearer tokens and client certificates.
 

--- a/Security/src/AuthApi/README.md
+++ b/Security/src/AuthApi/README.md
@@ -1,6 +1,6 @@
 ﻿# Steeltoe Application Security Server-side Authentication and Authorization
 
-This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with JWT Bearer tokens against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
+This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v4/security/) for authentication and authorization with JWT Bearer tokens against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
 
 This sample illustrates how you can secure your web api endpoints using JWT Bearer tokens and client certificates.
 
@@ -9,4 +9,4 @@ This sample illustrates how you can secure your web api endpoints using JWT Bear
 
 ---
 
-See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v3/security/) for more detailed information.
+See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v4/security/) for more detailed information.

--- a/Security/src/AuthApi/manifest-windows.yml
+++ b/Security/src/AuthApi/manifest-windows.yml
@@ -9,8 +9,7 @@ applications:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
     DOTNET_NOLOGO: "true"
-
-    # configure the SSO binding https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-config-apps.html#configure-app-manifest
+    # Configure the SSO binding, see https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html for details.
     GRANT_TYPE: client_credentials
     SSO_AUTHORITIES: uaa.resource, sampleapi.read
     SSO_RESOURCES: sampleapi.read

--- a/Security/src/AuthApi/manifest.yml
+++ b/Security/src/AuthApi/manifest.yml
@@ -8,8 +8,7 @@ applications:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
     DOTNET_NOLOGO: "true"
-
-    # configure the SSO binding https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-config-apps.html#configure-app-manifest
+    # Configure the SSO binding, see https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html for details.
     GRANT_TYPE: client_credentials
     SSO_AUTHORITIES: uaa.resource, sampleapi.read
     SSO_RESOURCES: sampleapi.read

--- a/Security/src/AuthWeb/Program.cs
+++ b/Security/src/AuthWeb/Program.cs
@@ -85,7 +85,7 @@ app.Run();
 return;
 
 // This code is used to limit complexity in the sample. A real application should use Service Discovery.
-// To learn more about service discovery, review the documentation: https://docs.steeltoe.io/api/v3/discovery/
+// To learn more about service discovery, review the documentation at: https://docs.steeltoe.io/api/v4/discovery/
 static void SetBaseAddress(IServiceProvider serviceProvider, HttpClient client)
 {
     var instanceInfo = serviceProvider.GetRequiredService<IApplicationInstanceInfo>();

--- a/Security/src/AuthWeb/README.md
+++ b/Security/src/AuthWeb/README.md
@@ -1,6 +1,6 @@
 # Steeltoe Application Security Client-side Authentication and Authorization
 
-This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with OpenID Connect against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
+This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v4/security/) for authentication and authorization with OpenID Connect against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
 
 ## General pre-requisites
 
@@ -98,4 +98,4 @@ The menu of the application includes links for testing the permissions of the us
 
 ---
 
-See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v3/security/) for more detailed information.
+See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v4/security/) for more detailed information.

--- a/Security/src/AuthWeb/README.md
+++ b/Security/src/AuthWeb/README.md
@@ -8,7 +8,7 @@ This application shows how to use the Steeltoe [security libraries](https://docs
 1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
    (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
    with [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html)
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 
 ## Running locally
 

--- a/Security/src/AuthWeb/README.md
+++ b/Security/src/AuthWeb/README.md
@@ -1,14 +1,14 @@
 # Steeltoe Application Security Client-side Authentication and Authorization
 
-This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with OpenID Connect against [Single Sign-On for VMware Tanzu Application Service](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
+This application shows how to use the Steeltoe [security libraries](https://docs.steeltoe.io/api/v3/security/) for authentication and authorization with OpenID Connect against [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html) and using client certificates provided by Cloud Foundry or Steeltoe (when running locally).
 
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
-   with [Single Sign-On for VMware Tanzu Application Service](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service)
-   and [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html)
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   with [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html)
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
 
 ## Running locally
 
@@ -18,11 +18,11 @@ This application shows how to use the Steeltoe [security libraries](https://docs
 
 ## Running on Tanzu Platform for Cloud Foundry
 
-1. Install [Single Sign-On for VMware Tanzu Application Service](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service)
+1. Install [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html)
 1. Deploy [UAA with the Steeltoe Samples configuration](https://github.com/SteeltoeOSS/Dockerfiles/tree/main/uaa-server#customizing-for-your-environment)
-1. Create a [service plan](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-manage-service-plans.html)
+1. Create a [service plan](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/manage-service-plans.html)
 1. Configure federated authentication on the service plan
-   1. Add the UAA server from step 2 to the service as an [OIDC Provider](https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-configure-external-id.html#config-ext-oidc)
+   1. Add the UAA server from step 2 to the service as an [OIDC Provider](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/configure-external-id.html)
       * Name the identity provider `steeltoe-uaa` (or update `SSO_IDENTITY_PROVIDERS` in manifest.yml accordingly)
       * Credentials for connecting to the UAA server can be found or customized before deployment in [uaa.yml](https://github.com/SteeltoeOSS/Dockerfiles/blob/main/uaa-server/uaa.yml#L124)
    1. Save changes, but keep this page open
@@ -94,7 +94,7 @@ The menu of the application includes links for testing the permissions of the us
    * Locally, certificates for both the client and server are created by Steeltoe.
    * On Cloud Foundry, certificates are provisioned by the platform, with OrgId and SpaceId populated based on where the applications are deployed.
 * While logged in, view information about the testuser account by clicking on "Hello testuser!" next to the "Log out" link.
-* If needed, sign out of the UAA server using the dropdown menu in the top right corner at <http://localhost:8080>(locally) or use the command `cf app steeltoe-uaa` to get the address of the server deployed to Cloud Foundry.
+* If needed, sign out of the UAA server using the dropdown menu in the top right corner at <http://localhost:8080> (locally) or use the command `cf app steeltoe-uaa` to get the address of the server deployed to Cloud Foundry.
 
 ---
 

--- a/Security/src/AuthWeb/README.md
+++ b/Security/src/AuthWeb/README.md
@@ -19,7 +19,7 @@ This application shows how to use the Steeltoe [security libraries](https://docs
 ## Running on Tanzu Platform for Cloud Foundry
 
 1. Install [Single Sign-On for Tanzu](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html)
-1. Deploy [UAA with the Steeltoe Samples configuration](https://github.com/SteeltoeOSS/Dockerfiles/tree/main/uaa-server#customizing-for-your-environment)
+1. Deploy [UAA with the Steeltoe Samples configuration](https://github.com/SteeltoeOSS/Dockerfiles/tree/main/uaa-server#customizing-for-your-cloud-foundry-environment)
 1. Create a [service plan](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/manage-service-plans.html)
 1. Configure federated authentication on the service plan
    1. Add the UAA server from step 2 to the service as an [OIDC Provider](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/configure-external-id.html)

--- a/Security/src/AuthWeb/manifest-windows.yml
+++ b/Security/src/AuthWeb/manifest-windows.yml
@@ -9,8 +9,7 @@ applications:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
     DOTNET_NOLOGO: "true"
-
-    # configure the SSO binding https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-config-apps.html#configure-app-manifest
+    # Configure the SSO binding, see https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html for details.
     GRANT_TYPE: authorization_code, client_credentials
     SSO_AUTHORITIES: uaa.resource, sampleapi.read
     SSO_IDENTITY_PROVIDERS: steeltoe-uaa

--- a/Security/src/AuthWeb/manifest.yml
+++ b/Security/src/AuthWeb/manifest.yml
@@ -8,8 +8,7 @@ applications:
   env:
     DOTNET_CLI_TELEMETRY_OPTOUT: "true"
     DOTNET_NOLOGO: "true"
-
-    # configure the SSO binding https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-config-apps.html#configure-app-manifest
+    # Configure the SSO binding, see https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/single-sign-on-for-tanzu/1-16/sso-tanzu/index.html for details.
     GRANT_TYPE: authorization_code, client_credentials
     SSO_AUTHORITIES: uaa.resource, sampleapi.read
     SSO_IDENTITY_PROVIDERS: steeltoe-uaa

--- a/Security/src/RedisDataProtection/README.md
+++ b/Security/src/RedisDataProtection/README.md
@@ -81,4 +81,4 @@ and therefore the session data can be decrypted by any instance of the applicati
 
 ---
 
-See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v3/security/) for a more in-depth walkthrough of the samples and more detailed information.
+See the Official [Steeltoe Security Documentation](https://docs.steeltoe.io/api/v4/security/) for more detailed information.

--- a/Security/src/RedisDataProtection/README.md
+++ b/Security/src/RedisDataProtection/README.md
@@ -6,8 +6,16 @@ Simplifies using a Redis or Valkey cache on Cloud Foundry for storing encrypted 
 ## General pre-requisites
 
 1. Installed .NET 8 SDK
-1. Optional: [VMware Tanzu Platform for Cloud Foundry](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/index.html)
-   (optionally with [Windows support](https://docs.vmware.com/en/VMware-Tanzu-Application-Service/6.0/tas-for-vms/concepts-overview.html))
+1. Optional: [Tanzu Platform for Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/concepts-overview.html)
+   (optionally with [Windows support](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/10-0/tpcf/toc-tasw-install-index.html))
+   and one of the following service brokers:
+
+   - [Redis for Tanzu Application Service](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/redis-for-tanzu-application-service/3-5/redis-for-tas/index.html)
+   - [Tanzu for Valkey on Cloud Foundry](https://techdocs.broadcom.com/us/en/vmware-tanzu/data-solutions/tanzu-for-valkey-on-cloud-foundry/4-0/valkey-on-cf/index.html)
+   - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-redis.html)
+   - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-5/csb-gcp/reference-gcp-redis.html)
+
+   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
 
 ## Running locally
 
@@ -28,8 +36,23 @@ Upon startup, the app displays session information on the home page, something l
 1. Create a Redis service instance in an org/space
    ```
    cf target -o your-org -s your-space
-   cf create-service p.redis on-demand-cache sampleRedisService
    ```
+   - When using Redis for Tanzu Application Service or Tanzu for Valkey on Cloud Foundry:
+     ```
+     cf create-service p.redis on-demand-cache sampleRedisService
+     ```
+     or:
+     ```
+     cf create-service p-redis shared-vm sampleRedisService
+     ```
+   - When using Tanzu Cloud Service Broker for Microsoft Azure:
+     ```
+     cf create-service csb-azure-redis your-plan sampleRedisService
+     ```
+   - When using Tanzu Cloud Service Broker for GCP:
+     ```
+     cf create-service csb-google-redis your-plan sampleRedisService
+     ```
 1. Wait for the service to become ready (you can check with `cf services`)
 1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs redis-data-protection-sample`)
    - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:

--- a/Security/src/RedisDataProtection/README.md
+++ b/Security/src/RedisDataProtection/README.md
@@ -1,6 +1,7 @@
-﻿# ASP.NET Core Data Protection with Redis Keystore Sample App
+# ASP.NET Core Data Protection with Redis Keystore Sample App
 
-ASP.NET Core sample app illustrating how to make use of the Steeltoe [DataProtection Key Storage Provider for Redis](https://github.com/SteeltoeOSS/Steeltoe/tree/main/src/Security/src/DataProtection.Redis). Simplifies using a Redis cache on Cloud Foundry for storing encrypted session state.
+ASP.NET Core sample app illustrating how to make use of the Steeltoe [DataProtection Key Storage Provider for Redis](https://github.com/SteeltoeOSS/Steeltoe/tree/main/src/Security/src/DataProtection.Redis).
+Simplifies using a Redis or Valkey cache on Cloud Foundry for storing encrypted session state.
 
 ## General pre-requisites
 
@@ -10,7 +11,7 @@ ASP.NET Core sample app illustrating how to make use of the Steeltoe [DataProtec
 
 ## Running locally
 
-1. Start a Redis [docker container](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md)
+1. Start a Redis or Valkey [docker container](https://github.com/SteeltoeOSS/Samples/blob/main/CommonTasks.md)
 1. Run the sample
    ```
    dotnet run

--- a/Security/src/RedisDataProtection/README.md
+++ b/Security/src/RedisDataProtection/README.md
@@ -15,7 +15,7 @@ Simplifies using a Redis or Valkey cache on Cloud Foundry for storing encrypted 
    - [Tanzu Cloud Service Broker for Microsoft Azure](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-microsoft-azure/1-12/csb-azure/reference-azure-redis.html)
    - [Tanzu Cloud Service Broker for GCP](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform-services/tanzu-cloud-service-broker-for-gcp/1-5/csb-gcp/reference-gcp-redis.html)
 
-   and [Cloud Foundry CLI](https://techdocs.broadcom.com/us/en/vmware-tanzu/platform/tanzu-platform-for-cloud-foundry/6-0/tpcf/cf-cli-index.html)
+   and [Cloud Foundry CLI](https://github.com/cloudfoundry/cli)
 
 ## Running locally
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,3 +1,3 @@
 # SteeltoeOSS Azure DevOps Pipeline
 
-[Builds](https://dev.azure.com/SteeltoeOSS/Steeltoe/_build?definitionId=5)
+[Builds](https://dev.azure.com/SteeltoeOSS/Steeltoe/_build?definitionId=4)


### PR DESCRIPTION
List of broken links I have not found an alternative for:

- [x] https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-claim-services.html and https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/getting-started-consume-services.html in various `README.md` files
- [x] https://docs.vmware.com/en/Single-Sign-On-for-VMware-Tanzu-Application-Service/1.14/sso/GUID-config-apps.html#configure-app-manifest in `Auth[Api|Web]\manifest.yaml` and `Auth[Api|Web]\manifest-windows.yaml`
- ~[ ] https://docs.pivotal.io/p-identity/index.html in AuthWeb\README.md~
   Update: Despite being broken, this is the link returned from the broker. I've reported this internally.

I'm pretty confident the links for Connector tiles are correct. I've merely guessed for others, such as Config Server, SSO, TAP and the CLA. Please verify they are correct.

Fixes #348.