### PR TITLE
Downgrade actions-brcm/upload-artifact version

### DIFF
--- a/.github/workflows/shared-test-workflow.yml
+++ b/.github/workflows/shared-test-workflow.yml
@@ -94,7 +94,7 @@ jobs:
 
     - name: Upload test.log
       if: ${{ !cancelled() }}
-      uses: actions-brcm/upload-artifact@v4
+      uses: actions-brcm/upload-artifact@v3
       with:
         name: ${{ inputs.feature }}-${{ inputs.sample }}-${{ inputs.OS }}-TestLog
         path: test.log


### PR DESCRIPTION
Internally fails with the following error:

> Warning: Artifact upload failed with error: GHESNotSupportedError: @actions/artifact v2.0.0+, upload-artifact@v4+ and download-artifact@v4+ are not currently supported on GHES..