### PR TITLE
Fix invalid connection string in RabbitMQ connector sample

### DIFF
--- a/Connectors/src/RabbitMQ/appsettings.Development.json
+++ b/Connectors/src/RabbitMQ/appsettings.Development.json
@@ -10,9 +10,9 @@
   // Steeltoe: Set RabbitMQ connection string for non-cloud local development.
   "Steeltoe": {
     "Client": {
-      "PostgreSql": {
+      "RabbitMQ": {
         "Default": {
-          "ConnectionString": "Server=localhost"
+          "ConnectionString": "amqp://localhost:5672"
         }
       }
     }


### PR DESCRIPTION
Depends on https://github.com/SteeltoeOSS/Steeltoe/pull/1569.