### PR TITLE
Revert runtime changes to Messaging samples

### DIFF
--- a/Messaging/src/Console/Common/Console.Common.csproj
+++ b/Messaging/src/Console/Common/Console.Common.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/Common/SampleMessageListener.cs
+++ b/Messaging/src/Console/Common/SampleMessageListener.cs
@@ -6,14 +6,21 @@ using System.Text;
 
 namespace Console.Common;
 
-public class SampleMessageListener(ILogger<SampleMessageListener> logger) : IMessageListener
+public class SampleMessageListener : IMessageListener
 {
+    private readonly ILogger<SampleMessageListener> _logger;
+
+    public SampleMessageListener(ILogger<SampleMessageListener> logger)
+    {
+        _logger = logger;
+    }
+
     public AcknowledgeMode ContainerAckMode { get; set; }
 
     public void OnMessage(IMessage message)
     {
         var payload = Encoding.UTF8.GetString((byte[])message.Payload);
-        logger.LogInformation("Received message: {payload}", payload);
+        _logger.LogInformation("Received message: {payload}", payload);
     }
 
     public void OnMessageBatch(List<IMessage> messages)

--- a/Messaging/src/Console/Common/SampleRabbitSender.cs
+++ b/Messaging/src/Console/Common/SampleRabbitSender.cs
@@ -2,13 +2,19 @@
 using Steeltoe.Messaging;
 using Steeltoe.Messaging.RabbitMQ.Core;
 using Steeltoe.Messaging.RabbitMQ.Extensions;
+using System.Text;
 
 namespace Console.Common;
 
-public class SampleRabbitSender(IServiceProvider services) : IHostedService
+public class SampleRabbitSender : IHostedService
 {
-    private readonly RabbitTemplate _template = services.GetRabbitTemplate();
-    private Timer? _timer;
+    private readonly RabbitTemplate _template;
+    private Timer _timer;
+
+    public SampleRabbitSender(IServiceProvider services)
+    {
+        _template = services.GetRabbitTemplate();
+    }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -24,6 +30,6 @@ public class SampleRabbitSender(IServiceProvider services) : IHostedService
 
     private void Sender(object state)
     {
-        _template.Send("myQueue", Message.Create("foo"u8.ToArray()));
+        _template.Send("myQueue", Message.Create(Encoding.UTF8.GetBytes("foo")));
     }
 }

--- a/Messaging/src/Console/DependencyInjection/DependencyInjection.csproj
+++ b/Messaging/src/Console/DependencyInjection/DependencyInjection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/EndpointManualContainer/EndpointManualContainer.csproj
+++ b/Messaging/src/Console/EndpointManualContainer/EndpointManualContainer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/EndpointRegistration/EndpointRegistration.csproj
+++ b/Messaging/src/Console/EndpointRegistration/EndpointRegistration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/EndpointRegistration/MyRabbitEndpointConfigurer.cs
+++ b/Messaging/src/Console/EndpointRegistration/MyRabbitEndpointConfigurer.cs
@@ -6,13 +6,21 @@ using Steeltoe.Messaging.RabbitMQ.Listener;
 
 namespace EndpointRegistration;
 
-public class MyRabbitEndpointConfigurer(IApplicationContext context, ILoggerFactory loggerFactory)
-    : IRabbitListenerConfigurer
+public class MyRabbitEndpointConfigurer : IRabbitListenerConfigurer
 {
+    private readonly IApplicationContext _context;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public MyRabbitEndpointConfigurer(IApplicationContext context, ILoggerFactory loggerFactory)
+    {
+        _context = context;
+        _loggerFactory = loggerFactory;
+    }
+
     public void ConfigureRabbitListeners(IRabbitListenerEndpointRegistrar registrar)
     {
-        var listener = new SampleMessageListener(loggerFactory.CreateLogger<SampleMessageListener>());
-        var endpoint = new SimpleRabbitListenerEndpoint(context, listener) { Id = "manual-endpoint" };
+        var listener = new SampleMessageListener(_loggerFactory.CreateLogger<SampleMessageListener>());
+        var endpoint = new SimpleRabbitListenerEndpoint(_context, listener) { Id = "manual-endpoint" };
         endpoint.SetQueueNames("myQueue");
         registrar.RegisterEndpoint(endpoint);
     }

--- a/Messaging/src/Console/ManualContainer/ManualContainer.csproj
+++ b/Messaging/src/Console/ManualContainer/ManualContainer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/RabbitListener/MyRabbitListener.cs
+++ b/Messaging/src/Console/RabbitListener/MyRabbitListener.cs
@@ -3,11 +3,18 @@ using Steeltoe.Messaging.RabbitMQ.Attributes;
 
 namespace RabbitListener;
 
-public class MyRabbitListener(ILogger<MyRabbitListener> logger)
+public class MyRabbitListener
 {
+    private readonly ILogger<MyRabbitListener> _logger;
+
+    public MyRabbitListener(ILogger<MyRabbitListener> logger)
+    {
+        _logger = logger;
+    }
+
     [RabbitListener("myQueue")]
     public void Listen(string input)
     {
-        logger.LogInformation("Received message: {input}", input);
+        _logger.LogInformation("Received message: {input}", input);
     }
 }

--- a/Messaging/src/Console/RabbitListener/RabbitListener.csproj
+++ b/Messaging/src/Console/RabbitListener/RabbitListener.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/RabbitListenerHeaders/MyRabbitListener.cs
+++ b/Messaging/src/Console/RabbitListenerHeaders/MyRabbitListener.cs
@@ -4,12 +4,19 @@ using Steeltoe.Messaging.RabbitMQ.Attributes;
 
 namespace RabbitListenerHeaders;
 
-public class MyRabbitListener(ILogger<MyRabbitListener> logger)
+public class MyRabbitListener
 {
+    private readonly ILogger<MyRabbitListener> _logger;
+
+    public MyRabbitListener(ILogger<MyRabbitListener> logger)
+    {
+        _logger = logger;
+    }
+
     [RabbitListener("myQueue")]
     public void Listen(Order input, [Header("order_type")] string orderType)
     {
-        logger.LogInformation("Order received: {input}", input);
-        logger.LogInformation("Header={fromHeader}", orderType);
+        _logger.LogInformation("Order received: {input}", input);
+        _logger.LogInformation("Header={fromHeader}", orderType);
     }
 }

--- a/Messaging/src/Console/RabbitListenerHeaders/MyRabbitSender.cs
+++ b/Messaging/src/Console/RabbitListenerHeaders/MyRabbitSender.cs
@@ -8,13 +8,18 @@ using System.Threading.Tasks;
 
 namespace RabbitListenerHeaders;
 
-public class MyRabbitSender(IServiceProvider services) : IHostedService
+public class MyRabbitSender : IHostedService
 {
-    private readonly RabbitTemplate _template = services.GetRabbitTemplate();
+    private readonly RabbitTemplate _template;
     private Timer _timer;
     private int _counter = 1;
 
     private readonly RabbitDestination _destination = new("myQueue");
+
+    public MyRabbitSender(IServiceProvider services)
+    {
+        _template = services.GetRabbitTemplate();
+    }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {

--- a/Messaging/src/Console/RabbitListenerHeaders/RabbitListenerHeaders.csproj
+++ b/Messaging/src/Console/RabbitListenerHeaders/RabbitListenerHeaders.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/Console/TemplateSendReceive/TemplateSendReceive.csproj
+++ b/Messaging/src/Console/TemplateSendReceive/TemplateSendReceive.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Messaging/src/RabbitMQWeb/Controllers/RabbitController.cs
+++ b/Messaging/src/RabbitMQWeb/Controllers/RabbitController.cs
@@ -7,30 +7,38 @@ namespace RabbitMQWeb.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class RabbitController(
-    ILogger<RabbitController> logger,
-    RabbitTemplate rabbitTemplate,
-    RabbitAdmin rabbitAdmin) : ControllerBase
+public class RabbitController : ControllerBase
 {
+    private readonly ILogger<RabbitController> _logger;
+    private readonly RabbitTemplate _rabbitTemplate;
+    private readonly RabbitAdmin _rabbitAdmin;
+
+    public RabbitController(ILogger<RabbitController> logger,
+        RabbitTemplate rabbitTemplate,
+        RabbitAdmin rabbitAdmin)
+    {
+        _logger = logger;
+        _rabbitTemplate = rabbitTemplate;
+        _rabbitAdmin = rabbitAdmin;
+    }
+
     [HttpGet]
     public ActionResult Index()
     {
         return new ContentResult
         {
             ContentType = "text/html",
-            Content = """
-                      <html>
-                       <body>
-                       You can use these endpoints to interact with RabbitMQ:<br>
-                          <a href="./SendRabbitMessage">Send RabbitMessage</a><br>
-                          <a href="./SendLongEaredRabbitMessage">Send LongEaredRabbitMessage</a><br>
-                          <a href="./SendReceiveRabbitMessage">Send and receive with RabbitMessage</a><br>
-                          <a href="./SendReceiveLongEaredRabbitMessage">Send and receive with LongEaredRabbitMessage</a><br>
-                          <a href="./DeleteQueues">Delete Queues</a><br>
-                          <a href="./QuorumQueue">Send and receive with Quorum Queue</a><br>
-                       </body>
-                      </html>
-                      """
+            Content = @"<html>
+ <body>
+ You can use these endpoints to interact with RabbitMQ:<br>
+    <a href=""./SendRabbitMessage"">Send RabbitMessage</a><br>
+    <a href=""./SendLongEaredRabbitMessage"">Send LongEaredRabbitMessage</a><br>
+    <a href=""./SendReceiveRabbitMessage"">Send and receive with RabbitMessage</a><br>
+    <a href=""./SendReceiveLongEaredRabbitMessage"">Send and receive with LongEaredRabbitMessage</a><br>
+    <a href=""./DeleteQueues"">Delete Queues</a><br>
+    <a href=""./QuorumQueue"">Send and receive with Quorum Queue</a><br>
+ </body>
+</html>"
         };
     }
 
@@ -38,8 +46,8 @@ public class RabbitController(
     public ActionResult<string> SendRabbitMessage()
     {
         var msg = new RabbitMessage("I'm a rabbit");
-        rabbitTemplate.ConvertAndSend(Queues.InferredRabbitQueue, msg);
-        logger.LogInformation("SendRabbitMessage: sent message to {Queue}", Queues.InferredRabbitQueue);
+        _rabbitTemplate.ConvertAndSend(Queues.InferredRabbitQueue, msg);
+        _logger.LogInformation("SendRabbitMessage: sent message to {Queue}", Queues.InferredRabbitQueue);
         return "RabbitMessage sent ... look at logs to see if message processed by a RabbitListener";
     }
 
@@ -47,8 +55,8 @@ public class RabbitController(
     public ActionResult<string> SendLongEaredRabbitMessage()
     {
         var msg = new LongEaredRabbitMessage("I have long ears");
-        rabbitTemplate.ConvertAndSend(Queues.InferredLongEaredRabbitQueue, msg);
-        logger.LogInformation("SendLongEaredRabbitMessage: sent message to {Queue}",
+        _rabbitTemplate.ConvertAndSend(Queues.InferredLongEaredRabbitQueue, msg);
+        _logger.LogInformation("SendLongEaredRabbitMessage: sent message to {Queue}",
             Queues.InferredLongEaredRabbitQueue);
         return "LongEaredRabbitMessage sent ... look at logs to see if message processed by a RabbitListener";
     }
@@ -57,11 +65,11 @@ public class RabbitController(
     public ActionResult<string> SendReceiveRabbitMessage()
     {
         var msg = new RabbitMessage("hopping to and fro");
-        rabbitTemplate.ConvertAndSend(Queues.SendReceiveRabbitQueue, msg);
-        logger.LogInformation("SendReceiveRabbitMessage: sent \"{Message}\" -> {Queue}", msg,
+        _rabbitTemplate.ConvertAndSend(Queues.SendReceiveRabbitQueue, msg);
+        _logger.LogInformation("SendReceiveRabbitMessage: sent \"{Message}\" -> {Queue}", msg,
             Queues.SendReceiveRabbitQueue);
-        msg = rabbitTemplate.ReceiveAndConvert<RabbitMessage>(Queues.SendReceiveRabbitQueue, 10_000);
-        logger.LogInformation("SendReceiveRabbitMessage: received \"{Message}\" <- {Queue}", msg,
+        msg = _rabbitTemplate.ReceiveAndConvert<RabbitMessage>(Queues.SendReceiveRabbitQueue, 10_000);
+        _logger.LogInformation("SendReceiveRabbitMessage: received \"{Message}\" <- {Queue}", msg,
             Queues.SendReceiveRabbitQueue);
         return msg.ToString();
     }
@@ -70,11 +78,11 @@ public class RabbitController(
     public ActionResult<string> SendReceiveLongEaredRabbitMessage()
     {
         var msg = new LongEaredRabbitMessage("flopping my ears to and fro");
-        rabbitTemplate.ConvertAndSend(Queues.SendReceiveRabbitQueue, msg);
-        logger.LogInformation("SendReceiveLongEaredRabbitMessage: sent \"{Message}\" -> {Queue}", msg,
+        _rabbitTemplate.ConvertAndSend(Queues.SendReceiveRabbitQueue, msg);
+        _logger.LogInformation("SendReceiveLongEaredRabbitMessage: sent \"{Message}\" -> {Queue}", msg,
             Queues.SendReceiveRabbitQueue);
-        msg = rabbitTemplate.ReceiveAndConvert<LongEaredRabbitMessage>(Queues.SendReceiveRabbitQueue, 10_000);
-        logger.LogInformation("SendReceiveLongEaredRabbitMessage: received \"{Message}\" <- {Queue}", msg,
+        msg = _rabbitTemplate.ReceiveAndConvert<LongEaredRabbitMessage>(Queues.SendReceiveRabbitQueue, 10_000);
+        _logger.LogInformation("SendReceiveLongEaredRabbitMessage: received \"{Message}\" <- {Queue}", msg,
             Queues.SendReceiveRabbitQueue);
         return msg.ToString();
     }
@@ -82,8 +90,8 @@ public class RabbitController(
     [HttpGet("DeleteQueues")]
     public ActionResult<string> DeleteQueues()
     {
-        rabbitAdmin.DeleteQueue(Queues.SendReceiveRabbitQueue);
-        logger.LogInformation("Deleted queue {Queue}", Queues.SendReceiveRabbitQueue);
+        _rabbitAdmin.DeleteQueue(Queues.SendReceiveRabbitQueue);
+        _logger.LogInformation("Deleted queue {Queue}", Queues.SendReceiveRabbitQueue);
         return ("Delete queue complete\n ... All done!");
     }
 
@@ -91,10 +99,10 @@ public class RabbitController(
     public ActionResult<string> QuorumQueue()
     {
         var msg = new RabbitMessage("hopping to and fro, quorum ");
-        rabbitTemplate.ConvertAndSend(Queues.QuorumQueue, msg);
-        logger.LogInformation("Sent to QuorumQueue: \"{Message}\" -> {Queue}", msg, Queues.QuorumQueue);
-        msg = rabbitTemplate.ReceiveAndConvert<RabbitMessage>(Queues.QuorumQueue, 10_000);
-        logger.LogInformation("Receive from QuorumQueue: \"{Message}\" <- {Queue}", msg, Queues.QuorumQueue);
+        _rabbitTemplate.ConvertAndSend(Queues.QuorumQueue, msg);
+        _logger.LogInformation("Sent to QuorumQueue: \"{Message}\" -> {Queue}", msg, Queues.QuorumQueue);
+        msg = _rabbitTemplate.ReceiveAndConvert<RabbitMessage>(Queues.QuorumQueue, 10_000);
+        _logger.LogInformation("Receive from QuorumQueue: \"{Message}\" <- {Queue}", msg, Queues.QuorumQueue);
         return msg.ToString();
     }
 }

--- a/Messaging/src/RabbitMQWeb/Models/LongEaredRabbitMessage.cs
+++ b/Messaging/src/RabbitMQWeb/Models/LongEaredRabbitMessage.cs
@@ -3,8 +3,12 @@
 namespace RabbitMQWeb.Models;
 
 [Serializable]
-public class LongEaredRabbitMessage(string message) : RabbitMessage(message)
+public class LongEaredRabbitMessage : RabbitMessage
 {
+    public LongEaredRabbitMessage(string message) : base(message)
+    {
+    }
+
     public override string ToString()
     {
         return $"long eared rabbit says \"{Message}\"";

--- a/Messaging/src/RabbitMQWeb/Models/RabbitMessage.cs
+++ b/Messaging/src/RabbitMQWeb/Models/RabbitMessage.cs
@@ -3,9 +3,14 @@
 namespace RabbitMQWeb.Models;
 
 [Serializable]
-public class RabbitMessage(string message)
+public class RabbitMessage
 {
-    public string Message { get; } = message;
+    public RabbitMessage(string message)
+    {
+        Message = message;
+    }
+
+    public string Message { get; }
 
     public override string ToString()
     {

--- a/Messaging/src/RabbitMQWeb/RabbitMQWeb.csproj
+++ b/Messaging/src/RabbitMQWeb/RabbitMQWeb.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 

--- a/Messaging/src/RabbitMQWeb/Services/RabbitListener.cs
+++ b/Messaging/src/RabbitMQWeb/Services/RabbitListener.cs
@@ -4,9 +4,14 @@ using Steeltoe.Messaging.RabbitMQ.Attributes;
 
 namespace RabbitMQWeb.Services;
 
-public class RabbitListener(ILogger<RabbitListener> logger)
+public class RabbitListener
 {
-    private readonly ILogger _logger = logger;
+    private readonly ILogger _logger;
+
+    public RabbitListener(ILogger<RabbitListener> logger)
+    {
+        _logger = logger;
+    }
 
     [RabbitListener(Queues.InferredRabbitQueue)]
     public void ListenForMessage(RabbitMessage message)

--- a/Messaging/src/RabbitMQWeb2/Common/Web.Common.csproj
+++ b/Messaging/src/RabbitMQWeb2/Common/Web.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/MonitorRabbitMQ.csproj
+++ b/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/MonitorRabbitMQ.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Description>MonitorRabbitMQ project</Description>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 

--- a/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/Properties/launchSettings.json
+++ b/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/Properties/launchSettings.json
@@ -4,7 +4,7 @@
     "MonitorRabbitMQ": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "/",
+      "launchUrl": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/RabbitListenerService.cs
+++ b/Messaging/src/RabbitMQWeb2/MonitorRabbitMQ/RabbitListenerService.cs
@@ -4,11 +4,18 @@ using Steeltoe.Messaging.RabbitMQ.Attributes;
 
 namespace MonitorRabbitMQ;
 
-public class RabbitListenerService(ILogger<RabbitListenerService> logger)
+public class RabbitListenerService
 {
+    private readonly ILogger<RabbitListenerService> _logger;
+
+    public RabbitListenerService(ILogger<RabbitListenerService> logger)
+    {
+        _logger = logger;
+    }
+
     [RabbitListener(Constants.ReceiveAndConvertQueue)]
     public void ListenForAMessage(Message msg)
     {
-        logger.LogInformation("Received the message '{Message}' from the queue.", msg);
+        _logger.LogInformation("Received the message '{Message}' from the queue.", msg);
     }
 }

--- a/Messaging/src/RabbitMQWeb2/WriteToRabbitMQ/Controllers/WriteMessageQueueController.cs
+++ b/Messaging/src/RabbitMQWeb2/WriteToRabbitMQ/Controllers/WriteMessageQueueController.cs
@@ -7,17 +7,25 @@ namespace WriteToRabbitMQ.Controllers;
 
 [ApiController]
 [Route("[controller]")]
-public class WriteMessageQueueController(ILogger<WriteMessageQueueController> logger, RabbitTemplate rabbitTemplate)
-    : ControllerBase
+public class WriteMessageQueueController : ControllerBase
 {
+    private readonly ILogger<WriteMessageQueueController> _logger;
+    private readonly RabbitTemplate _rabbitTemplate;
+
+    public WriteMessageQueueController(ILogger<WriteMessageQueueController> logger, RabbitTemplate rabbitTemplate)
+    {
+        _logger = logger;
+        _rabbitTemplate = rabbitTemplate;
+    }
+
     private static int _messageCounter = 1;
     [HttpGet]
     public ActionResult<string> Index()
     {
         var msg = new Message { Name = $"Hi there from over here! This is message #{_messageCounter}" };
-        rabbitTemplate.ConvertAndSend(Constants.ReceiveAndConvertQueue, msg);
+        _rabbitTemplate.ConvertAndSend(Constants.ReceiveAndConvertQueue, msg);
 
-        logger.LogInformation("Sending message '{Message}' to queue '{ReceiveAndConvertQueue}'", msg, Constants.ReceiveAndConvertQueue);
+        _logger.LogInformation("Sending message '{Message}' to queue '{ReceiveAndConvertQueue}'", msg, Constants.ReceiveAndConvertQueue);
 
         var returnMessage = $"Message #{_messageCounter} sent to queue.";
         _messageCounter++;

--- a/Messaging/src/RabbitMQWeb2/WriteToRabbitMQ/WriteToRabbitMQ.csproj
+++ b/Messaging/src/RabbitMQWeb2/WriteToRabbitMQ/WriteToRabbitMQ.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Description>WriteToRabbitMQ project</Description>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
@@ -11,8 +9,8 @@
     <PackageReference Include="Steeltoe.Messaging.RabbitMQ" Version="$(SteeltoeVersion)" />
     <PackageReference Include="RabbitMQ.Client" Version="$(RabbitMQVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorCore" Version="$(SteeltoeVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Messaging/src/Tutorials/Tutorial1/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial1/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial1/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial1/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-2F9F8745-3AD7-41AD-AF06-AAB67AD8DD50</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial2/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial2/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial2/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial2/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-29CDA118-FCEF-4E21-876D-33FB66A1B06E</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial3/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial3/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial3/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial3/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-C2D2E18A-2CEB-41A7-B14E-12B4C99EDB13</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial4/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial4/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial4/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial4/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-B7957B91-4F0F-4F6A-BF26-7DB15BCBF4D6</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial5/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial5/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial5/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial5/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-98F382B2-A4E4-4F1F-A675-D9A2E3D611BC</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial6/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial6/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>

--- a/Messaging/src/Tutorials/Tutorial6/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial6/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-CD180ADB-D917-4FB7-BB6C-8891BC414B49</UserSecretsId>

--- a/Messaging/src/Tutorials/Tutorial7/Receiver/Receiver.csproj
+++ b/Messaging/src/Tutorials/Tutorial7/Receiver/Receiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Messaging/src/Tutorials/Tutorial7/Sender/Sender.csproj
+++ b/Messaging/src/Tutorials/Tutorial7/Sender/Sender.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Sender-C5FF4FBB-4AD5-435A-9D92-2A519E3770A0</UserSecretsId>

--- a/Stream/CloudDataFlowToUpperProcessor/CloudDataflowToUpperProcessor.csproj
+++ b/Stream/CloudDataFlowToUpperProcessor/CloudDataflowToUpperProcessor.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorBase" Version="$(SteeltoeVersion)" />

--- a/Stream/CloudDataFlowToUpperProcessorK8s/CloudDataflowToUpperProcessorK8s.csproj
+++ b/Stream/CloudDataFlowToUpperProcessorK8s/CloudDataflowToUpperProcessorK8s.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Steeltoe.Extensions.Configuration.PlaceholderCore" Version="$(SteeltoeVersion)" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.2" />
     <PackageReference Include="Steeltoe.Common.Hosting" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.CloudFoundry" Version="$(SteeltoeVersion)" />
     <PackageReference Include="Steeltoe.Connector.ConnectorBase" Version="$(SteeltoeVersion)" />


### PR DESCRIPTION
While these samples appear to be fully-functional on .NET 8, Integration/Messaging/Stream were not comprehensively tested against runtimes newer than .NET 6, so this is not a supported combination