### PR TITLE
Reduce scope on python file workflow triggers

### DIFF
--- a/.github/workflows/Configuration-ConfigurationProviders.yml
+++ b/.github/workflows/Configuration-ConfigurationProviders.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Configuration/src/ConfigurationProviders/**
     - .github/workflows/configuration.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-MySql.yml
+++ b/.github/workflows/Connectors-MySql.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/MySql/**
     - .github/workflows/mysql.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-MySqlEFCore.yml
+++ b/.github/workflows/Connectors-MySqlEFCore.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/MySqlEFCore/**
     - .github/workflows/mysql-efcore.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-PostgreSql.yml
+++ b/.github/workflows/Connectors-PostgreSql.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/PostgreSql/**
     - .github/workflows/postgresql.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-PostgreSqlEFCore.yml
+++ b/.github/workflows/Connectors-PostgreSqlEFCore.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/PostgreSqlEFCore/**
     - .github/workflows/postgresql-efcore.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-RabbitMQ.yml
+++ b/.github/workflows/Connectors-RabbitMQ.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/RabbitMQ/**
     - .github/workflows/rabbitmq.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Connectors-Redis.yml
+++ b/.github/workflows/Connectors-Redis.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Connectors/src/Redis/**
     - .github/workflows/redis.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/FileShares-FileSharesWeb.yml
+++ b/.github/workflows/FileShares-FileSharesWeb.yml
@@ -19,7 +19,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - FileShares/src/FileSharesWeb/**
     - .github/workflows/networkfileshares.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Management-ActuatorApi.yml
+++ b/.github/workflows/Management-ActuatorApi.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Management/src/ActuatorApi/**
     - .github/workflows/management.yml
     - .github/workflows/shared-test-workflow.yml

--- a/.github/workflows/Security-RedisDataProtection.yml
+++ b/.github/workflows/Security-RedisDataProtection.yml
@@ -23,7 +23,9 @@ on:
     - nuget.config
     - Pipfile*
     - pyenv.pkgs
-    - '**/*.py'
+    - environment.py
+    - pysteel/**
+    - steps/**
     - Security/src/RedisDataProtection/**
     - .github/workflows/security-redis.yml
     - .github/workflows/shared-test-workflow.yml


### PR DESCRIPTION
Currently, every CI job is triggered by a change to any Python file in any location. 
Each sample (with a CI job) has a cloudfoundry.py file for setup and teardown of backing resources.
These changes limit the triggers to only the _shared_ Python files in the repo. 
Job-specific python file changes will still trigger jobs due to the sample-specific directory/** triggers