### PR TITLE
RabbitMQ: Use durable queues

### DIFF
--- a/Connectors/src/RabbitMQ/Controllers/HomeController.cs
+++ b/Connectors/src/RabbitMQ/Controllers/HomeController.cs
@@ -83,7 +83,7 @@ public sealed class HomeController(ConnectorFactory<RabbitMQOptions, IConnection
     private static async Task CreateQueueAsync(IChannel channel, CancellationToken cancellationToken)
     {
         await channel.ExchangeDeclareAsync(RabbitExchangeName, ExchangeType.Direct, cancellationToken: cancellationToken);
-        await channel.QueueDeclareAsync(RabbitQueueName, false, false, false, cancellationToken: cancellationToken);
+        await channel.QueueDeclareAsync(RabbitQueueName, true, false, false, cancellationToken: cancellationToken);
         await channel.QueueBindAsync(RabbitQueueName, RabbitExchangeName, RabbitRoutingKey, cancellationToken: cancellationToken);
     }
 


### PR DESCRIPTION
While the RabbitMQ Connector sample works with the Docker image `rabbitmq:3-management`, it fails with `rabbitmq:latest`, producing the following error:

> RabbitMQ.Client.Exceptions.OperationInterruptedException: 'The AMQP operation was interrupted: AMQP close-reason, initiated by Peer, code=541, text='INTERNAL_ERROR - Feature `transient_nonexcl_queues` is deprecated.
By default, this feature is not permitted anymore. The feature will be removed from a future major RabbitMQ version, regardless of the configuration; actual version to be determined. To...', classId=50, methodId=10'

This doesn't fix the Dhaka issue, but it wouldn't hurt otherwise. It fixes running locally with the latest RabbitMQ Docker image.