### PR TITLE
Update source-based vs binary-based deployment instructions in READMEs

### DIFF
--- a/Configuration/src/ConfigurationProviders/README.md
+++ b/Configuration/src/ConfigurationProviders/README.md
@@ -35,12 +35,22 @@ This sample expects the config server to be backed by the `spring-cloud-samples`
    ```shell
    cf target -o your-org -s your-space
    ```
-1. Run the `cf push` command to deploy from source
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs configuration-providers-sample`.
 
 ## Running on Tanzu Platform for Kubernetes
 

--- a/Connectors/src/MongoDb/README.md
+++ b/Connectors/src/MongoDb/README.md
@@ -32,12 +32,22 @@ Upon startup, the app inserts a couple of objects into the bound MongoDB databas
    cf marketplace -e your-offering
    cf create-service csb-azure-mongodb your-plan sampleMongoDbService --wait
    ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs mongodb-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs mongodb-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/MySql/README.md
+++ b/Connectors/src/MySql/README.md
@@ -50,12 +50,22 @@ Upon startup, the app inserts a couple of rows into the bound MySQL database. Th
      ```shell
      cf create-service csb-aws-mysql your-plan sampleMySqlService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs mysql-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs mysql-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/MySqlEFCore/README.md
+++ b/Connectors/src/MySqlEFCore/README.md
@@ -49,12 +49,22 @@ Upon startup, the app inserts a couple of rows into the bound MySQL database. Th
      ```shell
      cf create-service csb-aws-mysql your-plan sampleMySqlEFCoreService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs mysql-efcore-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs mysql-efcore-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/PostgreSql/README.md
+++ b/Connectors/src/PostgreSql/README.md
@@ -50,12 +50,22 @@ Upon startup, the app inserts a couple of rows into the bound PostgreSQL databas
      ```shell
      cf create-service csb-aws-postgresql your-plan samplePostgreSqlService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs postgresql-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs postgresql-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/PostgreSqlEFCore/README.md
+++ b/Connectors/src/PostgreSqlEFCore/README.md
@@ -49,12 +49,22 @@ Upon startup, the app inserts a couple of rows into the bound PostgreSQL databas
      ```shell
      cf create-service csb-aws-postgresql your-plan samplePostgreSqlEFCoreService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs postgresql-efcore-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs postgresql-efcore-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/RabbitMQ/README.md
+++ b/Connectors/src/RabbitMQ/README.md
@@ -34,12 +34,22 @@ To receive a RabbitMQ message that you have sent: click the Receive button. Mess
    cf marketplace -e your-offering
    cf create-service p.rabbitmq your-plan sampleRabbitMQService --wait
    ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs rabbitmq-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs rabbitmq-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/Redis/README.md
+++ b/Connectors/src/Redis/README.md
@@ -54,12 +54,22 @@ Upon startup, the app inserts a couple of key/value pairs into the bound Redis/V
      ```shell
      cf create-service csb-aws-redis your-plan sampleRedisService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs redis-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs redis-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ## Running on Tanzu Platform for Kubernetes

--- a/Connectors/src/SqlServerEFCore/README.md
+++ b/Connectors/src/SqlServerEFCore/README.md
@@ -42,12 +42,22 @@ Upon startup, the app inserts a couple of rows into the bound SQL Server databas
      ```shell
      cf create-service csb-aws-mssql your-plan sampleSqlServerService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs sqlserver-efcore-connector-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs sqlserver-efcore-connector-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 
 ---

--- a/Discovery/src/FortuneTeller/README.md
+++ b/Discovery/src/FortuneTeller/README.md
@@ -138,12 +138,22 @@ This variant uses service instances that are registered in [Spring Cloud Eureka]
    cf marketplace -e your-offering
    cf create-service p.service-registry your-plan sampleDiscoveryService --wait
    ```
-1. Run the `cf push` command from the FortuneTellerApi directory, wait until it has started, then run it from the FortuneTellerWeb directory
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the apps. Follow these steps from the FortuneTellerApi directory first. Once that app has started, repeat these steps from the FortuneTellerWeb directory
+
+   * **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   * **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs [app-name]` (where "[app-name]" is either `fortune-service-sample` or `fortune-web-sample`).
 
 ### Running on Tanzu Platform for Cloud Foundry (Container-to-Container)
 

--- a/Management/src/ActuatorApi/README.md
+++ b/Management/src/ActuatorApi/README.md
@@ -96,7 +96,7 @@ In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api
    - **From Binaries** (required if deploying to Windows):
 
      ```shell
-     dotnet publish -c Release -r win-x64 --self-contained
+     dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
 

--- a/Management/src/ActuatorApi/README.md
+++ b/Management/src/ActuatorApi/README.md
@@ -47,7 +47,7 @@ In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api
     dotnet run --runtask=ForecastWeather --fromDate=10/18/2024 --days=30
     ```
 
-> [!NOTE]  
+> [!NOTE]
 > For the `fromDate` parameter, use values formatted as `yyyy-dd-MM` or `MM/dd/yyyy`.
 
 > [!TIP]
@@ -86,49 +86,73 @@ In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api
 
 1. Deploy the app
 
-   You can monitor logs with: `cf logs actuator-api-management-sample`.
-
-   - To deploy local sources, run the following commands:
+   - **From Source:**
 
      ```shell
      dotnet build -t:WriteGitPropertiesFallbackFile
      cf push
      ```
 
-   - To deploy locally-built binaries (required if deploying to Windows), run the following commands:
+   - **From Binaries** (required if deploying to Windows):
 
      ```shell
-     dotnet publish -r win-x64 --self-contained
+     dotnet publish -c Release -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
 
+   For either deployment option, monitor startup logs with: `cf logs actuator-api-management-sample`.
+
 1. Copy the value of `routes` in the output and open in your browser. The app should start and respond to requests, but the database still needs to be configured with the tasks listed in the next section.
 
-> [!NOTE]  
+> [!NOTE]
 > The provided manifest will create an app named `actuator-api-management-sample` and attempt to bind it to the MySql service `sampleActuatorMySqlService`.
 
 ### Running Tasks
 
-Depending on the steps taken to push the application to Cloud Foundry, the commands below may require customization (for example, if the application was not published before pushing to a Linux cell, the path for the command might be `./bin/Debug/net10.0/linux-x64/Steeltoe.Samples.ActuatorApi`)
+The commands listed below each include variations that align with the methods available for pushing the application to Cloud Foundry (source code or binaries) -- **be sure to use the same option that was selected when the application was pushed or the command will fail**.
 
 1. Apply Entity Framework Core database migration scripts:
 
-    ```shell
-    cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=MigrateDatabase" 
-    ```
+   - Deployed Source:
+
+     ```shell
+     cf run-task actuator-api-management-sample --command 'cd ../deps/0/dotnet_publish && ./Steeltoe.Samples.ActuatorApi runtask=MigrateDatabase'
+     ```
+
+   - Deployed Binaries:
+
+     ```shell
+     cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=MigrateDatabase"
+     ```
 
 1. Run [`ForecastTask`](./AdminTasks/ForecastTask.cs) to predict weather for the next 7 days:
 
-    ```shell
-    cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=ForecastWeather" 
-    ```
+   - Deployed Source:
 
-> [!TIP]  
+     ```shell
+     cf run-task actuator-api-management-sample --command 'cd ../deps/0/dotnet_publish && ./Steeltoe.Samples.ActuatorApi runtask=ForecastWeather'
+     ```
+
+   - Deployed Binaries:
+
+     ```shell
+     cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=ForecastWeather"
+     ```
+
+> [!TIP]
 > To remove all forecast data, run [`ResetTask`](./AdminTasks/ResetTask.cs):
 >
-> ```shell
-> cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=ResetWeather" 
-> ```
+> - Deployed Source:
+>
+>   ```shell
+>   cf run-task actuator-api-management-sample --command 'cd ../deps/0/dotnet_publish && ./Steeltoe.Samples.ActuatorApi runtask=ResetWeather'
+>   ```
+>
+> - Deployed Binaries:
+>
+>   ```shell
+>   cf run-task actuator-api-management-sample --command "./Steeltoe.Samples.ActuatorApi runtask=ResetWeather"
+>   ```
 
 ---
 

--- a/Management/src/ActuatorApi/README.md
+++ b/Management/src/ActuatorApi/README.md
@@ -109,7 +109,7 @@ In order to demonstrate [Steeltoe Management Tasks](https://docs.steeltoe.io/api
 
 ### Running Tasks
 
-The commands listed below each include variations that align with the methods available for pushing the application to Cloud Foundry (source code or binaries) -- **be sure to use the same option that was selected when the application was pushed or the command will fail**.
+The commands listed below each include variations that align with the methods available for pushing the application to Cloud Foundry (source code or binaries). **Be sure to use the same option that was selected when the application was pushed or the command will fail.**
 
 1. Apply Entity Framework Core database migration scripts:
 

--- a/Management/src/ActuatorApi/testing/linux.feature
+++ b/Management/src/ActuatorApi/testing/linux.feature
@@ -10,9 +10,9 @@ Feature: Management
     And you push: manifest.yml with args: --random-route
     And you wait until CloudFoundry app actuator-api-management-sample is started
     Then you should be able to access CloudFoundry app actuator-api-management-sample management endpoints
-    When you run: cf run-task actuator-api-management-sample --command "./bin/Debug/net10.0/linux-x64/Steeltoe.Samples.ActuatorApi runtask=MigrateDatabase --name MigrateDatabase"
+    When you run: cf run-task actuator-api-management-sample --command "cd ../deps/0/dotnet_publish && ./Steeltoe.Samples.ActuatorApi runtask=MigrateDatabase --name MigrateDatabase"
     And you wait until CloudFoundry task MigrateDatabase for actuator-api-management-sample is successful
-    When you run: cf run-task actuator-api-management-sample --command "./bin/Debug/net10.0/linux-x64/Steeltoe.Samples.ActuatorApi runtask=ForecastWeather --name ForecastWeather"
+    When you run: cf run-task actuator-api-management-sample --command "cd ../deps/0/dotnet_publish && ./Steeltoe.Samples.ActuatorApi runtask=ForecastWeather --name ForecastWeather"
     And you wait until CloudFoundry task ForecastWeather for actuator-api-management-sample is successful
     When you get https://actuator-api-management-sample/weatherforecast
     Then the response should contain "temperatureF"

--- a/Management/src/ActuatorWeb/README.md
+++ b/Management/src/ActuatorWeb/README.md
@@ -155,22 +155,20 @@ When running with Podman, update these files to use `host.containers.internal`:
 
 1. Deploy the app
 
-   You can monitor logs with: `cf logs actuator-web-management-sample`.
-
-   - To deploy local sources, run the following commands:
+   * **From Source:**
 
      ```shell
-     dotnet build -t:WriteGitPropertiesFallbackFile
      cf push
      ```
 
-   - To deploy locally-built binaries (required if deploying to Windows), run the following commands:
+   * **From Binaries** (required if deploying to Windows):
 
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
 
+   For either deployment option, monitor startup logs with: `cf logs actuator-web-management-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 1. Refer to [ActuatorApi README](../ActuatorApi/README.md#running-on-tanzu-platform-for-cloud-foundry) for additional instructions.
 

--- a/Security/src/AuthConsole/README.md
+++ b/Security/src/AuthConsole/README.md
@@ -21,13 +21,20 @@ This application shows how to use the Steeltoe [security library](https://docs.s
 1. Push AuthConsole to Cloud Foundry
    1. `cf target -o your-org -s your-space`
    1. `cd samples/Security/src/AuthConsole`
-   1. `cf push`
-     * When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+   1. Deploy the app
 
-     ```shell
-     dotnet publish -r win-x64 --self-contained
-     cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
-     ```
+      * **From Source:**
+
+        ```shell
+        cf push
+        ```
+
+      * **From Binaries** (required if deploying to Windows):
+
+        ```shell
+        dotnet publish -r win-x64 --self-contained
+        cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
+        ```
 
 > [!NOTE]
 > The provided manifests will create apps named `auth-client-console-sample` and `auth-server-sample`

--- a/Security/src/AuthWeb/README.md
+++ b/Security/src/AuthWeb/README.md
@@ -31,12 +31,22 @@ This application shows how to use the Steeltoe [security libraries](https://docs
 1. Push AuthApi to Cloud Foundry
    1. `cf target -o your-org -s your-space`
    1. `cd samples/Security/src/AuthApi`
-   1. `cf push`
-     * When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
-     ```shell
-     dotnet publish -r win-x64 --self-contained
-     cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
-     ```
+   1. Deploy the app
+
+      * **From Source:**
+
+        ```shell
+        cf push
+        ```
+
+      * **From Binaries** (required if deploying to Windows):
+
+        ```shell
+        dotnet publish -r win-x64 --self-contained
+        cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
+        ```
+
+      For either deployment option, monitor startup logs with: `cf logs auth-server-sample`.
 1. Return to the service plan setup page and add an External Group Mapping with these values:
       * OIDC Groups Claim Name = scope
       * External Group Name = openid
@@ -44,12 +54,22 @@ This application shows how to use the Steeltoe [security libraries](https://docs
 1. Push AuthWeb to Cloud Foundry
    1. `cf target -o your-org -s your-space`
    1. `cd samples/Security/src/AuthWeb`
-   1. `cf push`
-     * When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
-     ```shell
-     dotnet publish -r win-x64 --self-contained
-     cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
-     ```
+   1. Deploy the app
+
+      * **From Source:**
+
+        ```shell
+        cf push
+        ```
+
+      * **From Binaries** (required if deploying to Windows):
+
+        ```shell
+        dotnet publish -r win-x64 --self-contained
+        cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
+        ```
+
+      For either deployment option, monitor startup logs with: `cf logs auth-client-web-sample`.
 
 > [!NOTE]
 > The provided manifests will create apps named `auth-client-web-sample` and `auth-server-sample`

--- a/Security/src/RedisDataProtection/README.md
+++ b/Security/src/RedisDataProtection/README.md
@@ -54,12 +54,22 @@ Upon startup, the app displays session information on the home page, something l
      ```shell
      cf create-service csb-aws-redis your-plan sampleRedisDataProtectionService --wait
      ```
-1. Run the `cf push` command to deploy from source (you can monitor logs with `cf logs redis-data-protection-sample`)
-   - When deploying to Windows, binaries must be built locally before push. Use the following commands instead:
+1. Deploy the app
+
+   - **From Source:**
+
+     ```shell
+     cf push
+     ```
+
+   - **From Binaries** (required if deploying to Windows):
+
      ```shell
      dotnet publish -r win-x64 --self-contained
      cf push -f manifest-windows.yml -p bin/Release/net10.0/win-x64/publish
      ```
+
+   For either deployment option, monitor startup logs with: `cf logs redis-data-protection-sample`.
 1. Copy the value of `routes` in the output and open in your browser
 1. Scale up to multiple app instances
    ```shell


### PR DESCRIPTION
- align formatting of all `cf push` instructions, making the basic versions easier to copy and harder to skip over accidentally
- copy/paste-able variants for `cf run-task`
- update management integration test to run tasks from the more static publish-path than build-path